### PR TITLE
JBQA-7495 Remove debug profile from red deer

### DIFF
--- a/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/org.jboss.reddeer.eclipse.test/pom.xml
@@ -13,14 +13,4 @@
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 
-	<profiles>
-		<profile>
-			<id>mvn-debug</id>
-			<properties>
-				<memoryOptions1>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y</memoryOptions1>
-				<systemProperties>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y</systemProperties>
-			</properties>
-		</profile>
-	</profiles>
-
 </project>

--- a/org.jboss.reddeer.parent/pom.xml
+++ b/org.jboss.reddeer.parent/pom.xml
@@ -103,7 +103,7 @@
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
 					<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
-					<argLine> ${memoryOptions1}</argLine>
+					<argLine> </argLine>
 					<product>org.eclipse.platform.ide</product>
 					<application>org.eclipse.ui.ide.workbench</application>
 					<dependencies>
@@ -149,12 +149,4 @@
 				</releases>
 		</repository>
 	</repositories>
-	<profiles>
-		<profile>
-			<id>mvn-debug</id>
-			<properties>
-				<systemProperties>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y</systemProperties>
-			</properties>
-		</profile>
-	</profiles>	
 </project>

--- a/org.jboss.reddeer.swt.test/pom.xml
+++ b/org.jboss.reddeer.swt.test/pom.xml
@@ -26,15 +26,5 @@
 		</plugins>
 	</build>	
 
-	<profiles>
-		<profile>
-			<id>mvn-debug</id>
-			<properties>
-				<memoryOptions1>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y</memoryOptions1>
-				<systemProperties>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y</systemProperties>
-			</properties>
-		</profile>
-	</profiles>
-
 
 </project>

--- a/org.jboss.reddeer.workbench.test/pom.xml
+++ b/org.jboss.reddeer.workbench.test/pom.xml
@@ -26,15 +26,5 @@
 		</plugins>
 	</build>	
 
-	<profiles>
-		<profile>
-			<id>mvn-debug</id>
-			<properties>
-				<memoryOptions1>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y</memoryOptions1>
-				<systemProperties>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y</systemProperties>
-			</properties>
-		</profile>
-	</profiles>
-
 
 </project>


### PR DESCRIPTION
As described in JBIDE-13022 there is no need to have special
 definitions for a debug profile for tycho. You can just use
 -DdebugPort=8001 (or any port of choice) in your maven
 build and tycho will take care of everything.
