### PR TITLE
Target platform updated Kepler M4

### DIFF
--- a/org.jboss.reddeer.parent/pom.xml
+++ b/org.jboss.reddeer.parent/pom.xml
@@ -10,7 +10,7 @@
 	
 	<properties>
   	    <tycho-version>0.14.0</tycho-version>  	  
-		<jbosstools-target-site>http://download.jboss.org/jbosstools/updates/juno/SR1a/REPO</jbosstools-target-site>
+		<jbosstools-target-site>http://download.jboss.org/jbosstools/updates/kepler/M4/REPO</jbosstools-target-site>
 	</properties>
 	
 	<modules>


### PR DESCRIPTION
We should always stay up to date with the latest Eclipse version
so I am moving the target platform version in parent pom.
This should also fix #22.
