### PR TITLE
ActiveWidget from WidgetLookup now works for editor as well. 

### DIFF
--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/impl/WorkbenchLookup.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/impl/WorkbenchLookup.java
@@ -3,8 +3,8 @@ package org.jboss.reddeer.swt.lookup.impl;
 import static org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable.syncExec;
 
 import org.eclipse.swtbot.swt.finder.results.Result;
+import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IViewReference;
-import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
@@ -31,6 +31,19 @@ public class WorkbenchLookup {
 	}
 	
 	/**
+	 * Returns active workbench part reference from current active workbench window
+	 * @return active workbench part reference
+	 */
+	public static IWorkbenchPartReference findActiveWorkbenchPart() {
+		return syncExec(new Result<IWorkbenchPartReference>() {
+			@Override
+			public IWorkbenchPartReference run() {
+				return activeWorkbenchWindow().getActivePage().getActivePartReference();
+			}
+		});
+	}
+	
+	/**
 	 * Returns active view reference from current active workbench window
 	 * @return active view reference
 	 */
@@ -43,29 +56,30 @@ public class WorkbenchLookup {
 	}
 	
 	/**
-	 * Returns all view references from current active workbench window
-	 * @return all view references
+	 * Returns active editor reference from current active workbench window
+	 * @return active editor reference
 	 */
-	public static IViewReference[] findAllViews() {
-		return syncExec(new Result<IViewReference[]>() {
-			public IViewReference[] run() {
-				return findActiveViewsInternal();
+	public static IEditorReference findActiveEditor() {
+		return syncExec(new Result<IEditorReference>() {
+			public IEditorReference run() {
+				return findActiveEditorInternal();
 			}
 		});
 	}
 
-	private static IWorkbenchPage activePageInternal() {
-		return activeWorkbenchWindow().getActivePage();
-	}
-	
-	private static IViewReference[] findActiveViewsInternal() {
-		return activePageInternal().getViewReferences();
-	}
-	
 	private static IViewReference findActiveViewInternal() {
-		IWorkbenchPartReference partReference = activePageInternal().getActivePartReference();
-		if (partReference instanceof IViewReference)
-			return (IViewReference) partReference;
+		IWorkbenchPartReference activeWorkbenchPart = findActiveWorkbenchPart(); 
+		if (activeWorkbenchPart instanceof IViewReference) {
+			return (IViewReference)activeWorkbenchPart;
+		}
+		return null;
+	}
+	
+	private static IEditorReference findActiveEditorInternal() {
+		IWorkbenchPartReference activeWorkbenchPart = findActiveWorkbenchPart(); 
+		if (activeWorkbenchPart instanceof IEditorReference) {
+			return (IEditorReference)activeWorkbenchPart;
+		}
 		return null;
 	}
 	


### PR DESCRIPTION
Additionally, instead of Display.getDisplay().getFocusControl() approach a new one is used - Control object directly mapped on WorkbenchPartReference is retrieved now -> this means that view/editor can now be parent control from which children discovering is performed
