### PR TITLE
Wait method in Tree Item discovering is more stable now

### DIFF
--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/AbstractTreeItem.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/AbstractTreeItem.java
@@ -14,7 +14,6 @@ import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.jboss.reddeer.swt.api.TreeItem;
-import org.jboss.reddeer.swt.condition.WaitCondition;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.lookup.impl.WidgetLookup;
 import org.jboss.reddeer.swt.wait.WaitUntil;
@@ -242,74 +241,3 @@ public abstract class AbstractTreeItem implements TreeItem {
 	}
 	
 }
-
-/**
- * Condition is fulfilled when tree item node is found after expanding 
- * 
- * @author jjankovi
- *
- */
-class TreeItemFoundAfterExpanding implements WaitCondition {
-
-	private String treeItemNode;
-	private SWTBotTreeItem item;
-	
-	public TreeItemFoundAfterExpanding(SWTBotTreeItem item, String treeItemNode) {
-		super();
-		this.treeItemNode = treeItemNode;
-		this.item = item;
-	}
-	
-	@Override
-	public boolean test() {
-		item.expand();
-		return nodeIsFound(treeItemNode);		
-	}
-
-	@Override
-	public String description() {
-		return "Tree item '" + treeItemNode + "' not found.";
-	}
-	
-	private boolean nodeIsFound(String treeItemNode) {
-		
-		try {
-			item.getNode(treeItemNode);
-			System.out.println(treeItemNode + " was found");
-			return true;
-		} catch (WidgetNotFoundException wnfe) {
-			item.collapse();
-			return false;
-		}
-		
-	}
-	
-}
-
-///**
-// * Condition is fulfilled when tree item is selected
-// * 
-// * @author jjankovi
-// *
-// */
-//class TreeItemIsSelected implements WaitCondition {
-//
-//	private SWTBotTreeItem item; 
-//	
-//	public TreeItemIsSelected(SWTBotTreeItem item) {
-//		super();
-//		this.item = item;
-//	}
-//
-//	@Override
-//	public boolean test() {
-//		item.select();
-//		return item.isSelected();
-//	}
-//
-//	@Override
-//	public String description() {
-//		return "Tree item '" + item.getText() + "' cannot be selected.";
-//	}
-//	
-//}

--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/DefaultTreeItem.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/DefaultTreeItem.java
@@ -100,7 +100,7 @@ protected final Logger logger = Logger.getLogger(this.getClass());
 			item = tree.getTreeItem(tiPath.get(0));
 			tiPath.remove(0);
 			for (String treeItemNode : tiPath) {
-				new WaitUntil(new TreeHasChildren(item));
+				new WaitUntil(new TreeItemFoundAfterExpanding(item, treeItemNode));
 				item = item.getNode(treeItemNode);
 			}
 			path = treeItemPath;
@@ -239,24 +239,39 @@ protected final Logger logger = Logger.getLogger(this.getClass());
  * @author jjankovi
  *
  */
-class TreeHasChildren implements WaitCondition {
+class TreeItemFoundAfterExpanding implements WaitCondition {
 
+	private String treeItemNode;
 	private SWTBotTreeItem item;
 	
-	public TreeHasChildren(SWTBotTreeItem item) {
+	public TreeItemFoundAfterExpanding(SWTBotTreeItem item, String treeItemNode) {
 		super();
+		this.treeItemNode = treeItemNode;
 		this.item = item;
 	}
 	
 	@Override
 	public boolean test() {
 		item.expand();
-		return item.getItems().length > 0;		
+		return nodeIsFound(treeItemNode);		
 	}
 
 	@Override
 	public String description() {
-		return "Tree item '" + item + "' has no children.";
+		return "Tree item '" + treeItemNode + "' not found.";
+	}
+	
+	private boolean nodeIsFound(String treeItemNode) {
+		
+		try {
+			item.getNode(treeItemNode);
+			System.out.println(treeItemNode + " was found");
+			return true;
+		} catch (WidgetNotFoundException wnfe) {
+			item.collapse();
+			return false;
+		}
+		
 	}
 	
 }


### PR DESCRIPTION
Supposing Tree items are generated after parent Tree Item expansion. Let's say first child Tree Item is generated as first one and the second child Tree Item as second one.

With current approach there is waiting until at least one child in Tree Item is found. In our case it would stop after first child Tree Item discovering. Problem is, that if we wanted the second child Tree Item, it will be not found cause it is generated later then the first one so children discovering process returns only one child not two children Tree Items.
