### PR TITLE
Add -XstartOnFirstThread for mac - fix

### DIFF
--- a/org.jboss.reddeer.parent/pom.xml
+++ b/org.jboss.reddeer.parent/pom.xml
@@ -12,6 +12,7 @@
  	   	<tycho-version>0.14.0</tycho-version>  	  
 		<eclipse-target-site>http://download.eclipse.org/releases/kepler</eclipse-target-site>
 		<swtbot-update-site>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site</swtbot-update-site>
+		<platformSystemProperties></platformSystemProperties>
 	</properties>
 	
 	<modules>


### PR DESCRIPTION
This is a fix for the previous commit - that one had a conflict
which was resolved badly - it missed the empty property definition.
