### PR TITLE
Selection of AbstractTreeItem doesn't work

### DIFF
--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/AbstractTreeItem.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/AbstractTreeItem.java
@@ -112,6 +112,7 @@ public abstract class AbstractTreeItem implements TreeItem {
 	
 	@Override
 	public void select() {
+		item.select();
 		new WaitUntil(new TreeItemIsSelected(item));
 	}
 	


### PR DESCRIPTION
While I was fixing logic in Wait condition used in tree item selection I forgot to apply it on deprecated AbstractTreeItem as well. It is fixed now
