### PR TITLE
Add license description to feature

### DIFF
--- a/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer Direct
+Bundle-Name: RedDeer Direct
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.direct
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.redder.direct.Activator

--- a/org.jboss.reddeer.direct/about.html
+++ b/org.jboss.reddeer.direct/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.direct/build.properties
+++ b/org.jboss.reddeer.direct/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
+               about.html,\
                .

--- a/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer Eclipse Componnet Tests
+Bundle-Name: RedDeer Eclipse Componnet Tests
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.eclipse.test;singleton:=true
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.eclipse.test.Activator

--- a/org.jboss.reddeer.eclipse.test/about.html
+++ b/org.jboss.reddeer.eclipse.test/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.eclipse.test/build.properties
+++ b/org.jboss.reddeer.eclipse.test/build.properties
@@ -3,4 +3,5 @@ source.. = src/,\
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
+               about.html,\
                plugin.xml

--- a/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer Eclipse Component
+Bundle-Name: RedDeer Eclipse Component
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.eclipse
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.eclipse.Activator

--- a/org.jboss.reddeer.eclipse/about.html
+++ b/org.jboss.reddeer.eclipse/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.eclipse/build.properties
+++ b/org.jboss.reddeer.eclipse/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
+               about.html,\
                .

--- a/org.jboss.reddeer.feature/feature.xml
+++ b/org.jboss.reddeer.feature/feature.xml
@@ -1,20 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.jboss.reddeer.feature"
-      label="Red Deer Feature"
-      version="0.2.0.qualifier">
+      label="RedDeer Feature"
+      version="0.2.0.qualifier"
+      provider-name="JBoss by Red Hat">
 
-   <description url="http://www.example.com/description">
-      [Enter Feature Description here.]
+   <description url="https://github.com/jboss-reddeer/reddeer/wiki">
+An extendable framework to support building automated Eclipse tests.
    </description>
 
-   <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+   <copyright>
+JBoss, Home of Professional Open Source
+Copyright (c) Red Hat, Inc., and individual contributors as indicated
+by the @authors tag, 2012-2013. See the copyright.txt in the distribution
+for a full listing of individual contributors.
    </copyright>
 
-   <license url="http://www.example.com/license">
-      [Enter License Description here.]
+   <license>
+      Red Hat, Inc. licenses these features and plugins to you under
+certain open source licenses (or aggregations of such licenses),
+which in a particular case may include the Eclipse Public License,
+the GNU Lesser General Public License, and/or certain other open
+source licenses. For precise licensing details, consult the corresponding
+source code, or contact Red Hat Legal Affairs, 1801 Varsity Drive,
+Raleigh NC 27606 USA.
    </license>
+
 
    <plugin
          id="org.jboss.reddeer.swt"

--- a/org.jboss.reddeer.gef/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.gef/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer GEF Component
+Bundle-Name: RedDeer GEF Component
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.gef
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.gef.Activator

--- a/org.jboss.reddeer.gef/about.html
+++ b/org.jboss.reddeer.gef/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.gef/build.properties
+++ b/org.jboss.reddeer.gef/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
+               about.html,\
                .

--- a/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer JFace Componnet Tests
+Bundle-Name: RedDeer JFace Componnet Tests
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.jface.test;singleton:=true
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.test.Activator

--- a/org.jboss.reddeer.jface.test/about.html
+++ b/org.jboss.reddeer.jface.test/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.jface.test/build.properties
+++ b/org.jboss.reddeer.jface.test/build.properties
@@ -1,3 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\ 
+               about.html,\
+               .

--- a/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer JFace Componnet
+Bundle-Name: RedDeer JFace Componnet
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.jface
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.Activator

--- a/org.jboss.reddeer.jface/about.html
+++ b/org.jboss.reddeer.jface/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.jface/build.properties
+++ b/org.jboss.reddeer.jface/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
+               about.html,\
                .

--- a/org.jboss.reddeer.junit.test/about.html
+++ b/org.jboss.reddeer.junit.test/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer JUnit Support
+Bundle-Name: RedDeer JUnit Support
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.junit
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.Activator

--- a/org.jboss.reddeer.junit/about.html
+++ b/org.jboss.reddeer.junit/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.junit/build.properties
+++ b/org.jboss.reddeer.junit/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
+               about.html,\
                lib/commons-beanutils-core-1.8.3.jar

--- a/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer Selenium Component
+Bundle-Name: RedDeer Selenium Component
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.selenium
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.redderr.bot.selenium.Activator

--- a/org.jboss.reddeer.selenium/about.html
+++ b/org.jboss.reddeer.selenium/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.selenium/build.properties
+++ b/org.jboss.reddeer.selenium/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
+               about.html,\
                .

--- a/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer SWT Component Tests
+Bundle-Name: RedDeer SWT Component Tests
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.swt.test;singleton:=true
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.test.Activator

--- a/org.jboss.reddeer.swt.test/about.html
+++ b/org.jboss.reddeer.swt.test/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.swt.test/build.properties
+++ b/org.jboss.reddeer.swt.test/build.properties
@@ -3,4 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                src/log4j.xml,\
+               about.html,\
                plugin.xml

--- a/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer SWT Component
+Bundle-Name: RedDeer SWT Component
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.swt
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.Activator

--- a/org.jboss.reddeer.swt/about.html
+++ b/org.jboss.reddeer.swt/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.swt/build.properties
+++ b/org.jboss.reddeer.swt/build.properties
@@ -2,5 +2,6 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
+               about.html,\
                src/log4j.xml
 additional.bundles = org.eclipse.swtbot.go

--- a/org.jboss.reddeer.wiki.examples/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.wiki.examples/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer Wiki Examples
+Bundle-Name: RedDeer Wiki Examples
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.wiki.examples
 Bundle-Version: 0.2.0.qualifier
 Require-Bundle: org.jboss.reddeer.eclipse,

--- a/org.jboss.reddeer.wiki.examples/about.html
+++ b/org.jboss.reddeer.wiki.examples/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.wiki.examples/build.properties
+++ b/org.jboss.reddeer.wiki.examples/build.properties
@@ -1,4 +1,5 @@
 source.. = src/,\
            resources/
 bin.includes = META-INF/,\
+               about.html,\
                .

--- a/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer Workbench Component Tests
+Bundle-Name: RedDeer Workbench Component Tests
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.workbench.test;singleton:=true
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.test.Activator

--- a/org.jboss.reddeer.workbench.test/about.html
+++ b/org.jboss.reddeer.workbench.test/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.workbench.test/build.properties
+++ b/org.jboss.reddeer.workbench.test/build.properties
@@ -1,3 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\ 
+               about.html,\
+               .

--- a/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Red Deer Workbench Component
+Bundle-Name: RedDeer Workbench Component
+Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.workbench
 Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.Activator

--- a/org.jboss.reddeer.workbench/about.html
+++ b/org.jboss.reddeer.workbench/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<HTML>
+
+<head>
+<title>About</title>
+<meta http-equiv=Content-Type content="text/html; charset=ISO-8859-1">
+</head>
+
+<BODY lang="EN-US">
+
+<H3>About This Content</H3>
+
+<P>&copy;2010 Red Hat, Inc. All rights reserved</P>
+
+<H3>License</H3>
+
+<P>Red Hat Inc., through its JBoss division, makes available all content in this plug-in 
+("Content"). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+("EPL"). A copy of the EPL is available at
+<A href="http://www.eclipse.org/org/documents/epl-v10.php">http://www.eclipse.org/org/documents/epl-v10.php</A>. 
+For purposes of the EPL, "Program" will mean the Content.</P>
+
+<P>If you did not receive this Content directly from Red Hat Inc., the 
+Content is being redistributed by another party ("Redistributor") and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at
+  <A href="http://www.jboss.org/tools">http://www.jboss.org/tools</A>.</P>
+
+</BODY>
+</HTML>

--- a/org.jboss.reddeer.workbench/build.properties
+++ b/org.jboss.reddeer.workbench/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
+               about.html,\
                .


### PR DESCRIPTION
When installing Reddeer via update site there is no License Info displayed.
Also once installed there is missing info in these places:
- Help > About Eclipse > Installation Details > Installed software > select reddeer feature > Properties >
  no Copyright, General Information, License Agreement info.
- Help > About Eclipse > Installation Details > Plugins - reddeer plugins has no Legal Info
