### PR TITLE
Wizard API supporting dynamic pages reimplementation

### DIFF
--- a/org.jboss.reddeer.jface.test/src/org/jboss/reddeer/jface/test/wizard/TestingWizard.java
+++ b/org.jboss.reddeer.jface.test/src/org/jboss/reddeer/jface/test/wizard/TestingWizard.java
@@ -1,7 +1,11 @@
 package org.jboss.reddeer.jface.test.wizard;
 
+import java.util.Properties;
+
+import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.jboss.reddeer.swt.util.Display;
@@ -9,14 +13,16 @@ import org.jboss.reddeer.swt.util.Display;
 public class TestingWizard extends Wizard {
 
 	private boolean finishEnabled = true;
-	
+	private Properties properties;
+
 	public TestingWizard() {
+		properties = new Properties();
 	}
 
 	@Override
 	public void addPages() {
-		addPage(new TestingPage("A"));
-		addPage(new TestingPage("B"));
+		addPage(new TestingPage("A", properties));
+		addPage(new TestingPage("B", properties));
 	}
 
 	@Override
@@ -28,43 +34,70 @@ public class TestingWizard extends Wizard {
 		}
 		return true;
 	}
-	
+
 	@Override
 	public boolean canFinish() {
 		return finishEnabled;
 	}
-	
+
 	public void setFinishEnabled(boolean finishEnabled) {
 		this.finishEnabled = finishEnabled;
 		Display.syncExec(new Runnable() {
-			
+
 			@Override
 			public void run() {
-				getContainer().updateButtons();				
+				getContainer().updateButtons();
 			}
 		});
 	}
-	
+
 	private static class TestingPage extends org.eclipse.jface.wizard.WizardPage {
 
 		private String pageName;
+		private Properties properties;
+		private org.eclipse.swt.widgets.Text text;
+		private org.eclipse.swt.widgets.Label label;
 
-		protected TestingPage(String pageName) {
+		protected TestingPage(String pageName, Properties properties) {
 			super(pageName);
 			this.pageName = pageName;
+			this.properties = properties;
+		}
+		
+		@Override
+		public void setVisible(boolean visible) {
+			super.setVisible(visible);
+			String name = properties.getProperty("name");
+			if (name != null) { 
+				label.setText("Age:");
+			}
 		}
 
 		@Override
 		public void createControl(Composite parent) {
 			Composite composite = new Composite(parent, SWT.NONE);
 			GridLayout gl = new GridLayout();
-			gl.numColumns = 1;
-			composite.setLayout(gl);	
-			
-			org.eclipse.swt.custom.CLabel id = new org.eclipse.swt.custom.CLabel(composite, SWT.LEFT);
+			gl.numColumns = 2;
+			composite.setLayout(gl);
+
+			GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+			gd.horizontalSpan=2;org.eclipse.swt.custom.CLabel id = new org.eclipse.swt.custom.CLabel(composite, SWT.LEFT);
 			id.setText(pageName);
+			id.setLayoutData(gd);
+			label = new org.eclipse.swt.widgets.Label(composite, SWT.NULL);
+			label.setText("Name:");
+			text = new org.eclipse.swt.widgets.Text(composite, SWT.BORDER | SWT.SINGLE);
+			text.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+			
 			setControl(composite);
+		}
+
+		@Override
+		public IWizardPage getNextPage() {
+			if (text != null && text.getText().length() > 0) {
+				properties.put("name", text.getText());
+			}
+			return super.getNextPage();
 		}
 	}
 }
-

--- a/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardDialog.java
+++ b/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardDialog.java
@@ -1,6 +1,13 @@
 package org.jboss.reddeer.eclipse.jface.wizard;
 
+import static org.hamcrest.Matchers.allOf;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
 import org.apache.log4j.Logger;
+import org.hamcrest.Matcher;
 import org.jboss.reddeer.eclipse.jface.exception.JFaceLayerException;
 import org.jboss.reddeer.swt.api.Button;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
@@ -11,75 +18,147 @@ import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 
 /**
- * A dialog where are wizard pages displayed. It can operate Next, Back, Cancel and Finish buttons. 
+ * A dialog where are wizard pages displayed. It can operate Next, Back, Cancel
+ * and Finish buttons.
  * 
  * @author Lucia Jelinkova
- *
+ * @author apodhrad
+ * 
  */
-public abstract class WizardDialog {
+public class WizardDialog {
 
 	protected final Logger log = Logger.getLogger(this.getClass());
+
+	protected int currentPage;
+	protected Properties properties;
+	protected Map<WizardPage, Matcher<WizardDialog>> wizardPageMap;
+
+	public WizardDialog() {
+		properties = new Properties();
+		wizardPageMap = new HashMap<WizardPage, Matcher<WizardDialog>>();
+	}
+
+	public void setProperty(Object key, Object value) {
+		properties.put(key, value);
+	}
+
+	public Object getProperty(Object key) {
+		return properties.get(key);
+	}
+
+	/**
+	 * Returns the first wizard page
+	 * 
+	 * @return first wizard page
+	 */
+	public WizardPage getFirstPage() {
+		return getWizardPage();
+	}
+
+	/**
+	 * Returns a current wizard page
+	 * 
+	 * @return current wizard page
+	 */
+	public WizardPage getWizardPage() {
+		for (WizardPage wizardPage : wizardPageMap.keySet()) {
+			Matcher<WizardDialog> matcher = wizardPageMap.get(wizardPage);
+			if (matcher.matches(this)) {
+				return wizardPage;
+			}
+		}
+		log.warn("No wizard page found in page index '" + currentPage + "'");
+		return null;
+	}
+
+	/**
+	 * Adds a new wizard page
+	 * 
+	 * @param page
+	 *            wizard page
+	 * @param pageIndex
+	 *            wizard page index
+	 */
+	public void addWizardPage(WizardPage page, int pageIndex) {
+		page.setWizardDialog(this);
+		wizardPageMap.put(page, new WizardPageIndex(pageIndex));
+	}
 	
-	protected int currentPage = 0;
-	
-	public abstract WizardPage getFirstPage();
-	
-	public void finish(){
+	/**
+	 * Adds a new wizard page
+	 * 
+	 * @param page
+	 *            wizard page
+	 * @param pageIndex
+	 *            wizard page index
+	 * @param matcher
+	 *            matcher when the wizard page will be displayed
+	 */
+	@SuppressWarnings("unchecked")
+	public void addWizardPage(WizardPage page, int pageIndex, Matcher<WizardDialog> matcher) {
+		page.setWizardDialog(this);
+		wizardPageMap.put(page, allOf(new WizardPageIndex(pageIndex), matcher));
+	}
+
+	public void finish() {
 		log.info("Finish wizard");
 
 		DefaultShell shell = new DefaultShell();
 		Button button = new PushButton("Finish");
 		checkButtonEnabled(button);
 		button.click();
-		
+
 		new WaitWhile(new ShellWithTextIsActive(shell.getText()), TimePeriod.LONG);
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 	}
-	
-	public void cancel(){
+
+	public void cancel() {
 		log.info("Cancel wizard");
-		
+
 		DefaultShell shell = new DefaultShell();
-		new PushButton("Cancel").click();		
-		
+		new PushButton("Cancel").click();
+
 		new WaitWhile(new ShellWithTextIsActive(shell.getText()));
 		new WaitWhile(new JobIsRunning());
 	}
-	
-	public void next(){
+
+	public void next() {
 		log.info("Go to next wizard page");
-		
+
 		Button button = new PushButton("Next >");
 		checkButtonEnabled(button);
 		button.click();
 		currentPage++;
 	}
-	
-	public void back(){
+
+	public void back() {
 		log.info("Go to previous wizard page");
 		Button button = new PushButton("< Back");
 		checkButtonEnabled(button);
 		button.click();
 		currentPage--;
 	}
-	
-	protected void checkButtonEnabled(Button button){
-		if (!button.isEnabled()){
+
+	protected void checkButtonEnabled(Button button) {
+		if (!button.isEnabled()) {
 			throw new JFaceLayerException("Button '" + button.getText() + "' is not enabled");
 		}
 	}
-	
-	public void selectPage(int pageIndex){
-	  if (pageIndex != currentPage){
-	    boolean goBack = pageIndex < currentPage;
-	    while (pageIndex != currentPage){
-	      if (goBack){
-	        back();
-	      }
-	      else{
-	        next();
-	      }
-	    }
-	  }  
+
+	public void selectPage(int pageIndex) {
+		if (pageIndex != currentPage) {
+			boolean goBack = pageIndex < currentPage;
+			while (pageIndex != currentPage) {
+				if (goBack) {
+					back();
+				} else {
+					next();
+				}
+			}
+		}
+	}
+
+	public int getPageIndex() {
+		return currentPage;
 	}
 }

--- a/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPage.java
+++ b/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPage.java
@@ -2,30 +2,64 @@ package org.jboss.reddeer.eclipse.jface.wizard;
 
 import org.apache.log4j.Logger;
 
+/**
+ * Wizard page
+ * 
+ * @author apodhrad
+ * 
+ */
 public abstract class WizardPage {
 
 	protected final Logger log = Logger.getLogger(this.getClass());
+
 	private WizardDialog wizardDialog;
 	private int pageIndex;
+
 	/**
-	 * Abstract class for Wizard page displayed within wizardDialog
-	 * on the pageIndex page
+	 * A wizard page should not know on which page index it is displayed. The
+	 * wizard page can also exist outside WizardDialog. Use no-argument
+	 * constructor instead.
+	 * 
 	 * @param wizardDialog
 	 * @param pageIndex
 	 */
-	protected WizardPage (WizardDialog wizardDialog, int pageIndex) {
-	  this.wizardDialog = wizardDialog;
-	  this.pageIndex = pageIndex;
+	@Deprecated
+	protected WizardPage(WizardDialog wizardDialog, int pageIndex) {
+		this.wizardDialog = wizardDialog;
+		this.pageIndex = pageIndex;
 	}
-	/**
-	 * Shows wizard page within wizard dialog
-	 * Wizard dialog has to be open before
-	 */
-	public void show(){
-	  wizardDialog.selectPage(pageIndex);
+
+	protected WizardPage() {
+
 	}
-	
+
+	public void setWizardDialog(WizardDialog wizardDialog) {
+		this.wizardDialog = wizardDialog;
+	}
+
 	public WizardDialog getWizardDialog() {
 		return wizardDialog;
-	}	
+	}
+
+	/**
+	 * This method in origin shows wizard page within wizard dialog. Wizard
+	 * dialog has to be open before. Use methods next() or back() in
+	 * WizardDialog to show the wizard page.
+	 */
+	@Deprecated
+	public void show() {
+		if (wizardDialog == null) {
+			throw new IllegalStateException("WizardDialog was not initialized!");
+		}
+		wizardDialog.selectPage(pageIndex);
+	}
+
+	/**
+	 * Fills the wizard page if implemented
+	 * 
+	 * @param obj
+	 */
+	public void fillWizardPage(Object... obj) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPageIndex.java
+++ b/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPageIndex.java
@@ -1,0 +1,36 @@
+package org.jboss.reddeer.eclipse.jface.wizard;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * Matches a wizard dialog with a given page index
+ * 
+ * @author apodhrad
+ * 
+ */
+public class WizardPageIndex extends BaseMatcher<WizardDialog> {
+
+	private int pageIndex;
+
+	public WizardPageIndex(int pageIndex) {
+		this.pageIndex = pageIndex;
+	}
+
+	/**
+	 * Returns true if the wizard dialog is in a given page index
+	 */
+	@Override
+	public boolean matches(Object item) {
+		if (item instanceof WizardDialog) {
+			WizardDialog wizardDialog = (WizardDialog) item;
+			return wizardDialog.getPageIndex() == pageIndex;
+		}
+		return false;
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("with page index '" + pageIndex + "'");
+	}
+}

--- a/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPageProperty.java
+++ b/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPageProperty.java
@@ -1,0 +1,43 @@
+package org.jboss.reddeer.eclipse.jface.wizard;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * Matches a wizard dialog with a given property
+ * 
+ * @author apodhrad
+ * 
+ */
+public class WizardPageProperty extends BaseMatcher<WizardDialog> {
+
+	private Object key;
+	private Object value;
+
+	public WizardPageProperty(Object key, Object value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	/**
+	 * Returns true if a wizard dialog contains a given property
+	 */
+	@Override
+	public boolean matches(Object item) {
+		if (item instanceof WizardDialog) {
+			WizardDialog wizardDialog = (WizardDialog) item;
+			Object value = wizardDialog.getProperty(this.key);
+			if (value != null) {
+				return value.equals(this.value);
+			} else {
+				return this.value == null;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("with property '" + key + "=" + value + "'");
+	}
+}


### PR DESCRIPTION
Hi folks,

I started writing some wizards for my tests using red deer and I got some troubles.
For example, my wizard consists of several pages and some "next" pages depend on the previous ones.

Page A (contains attribute name)
-> if name = "xyz" then go to the Page B1
-> if name = "zyx" then go to the Page B2

Note that pages B1 and B2 differ a lot, so my test wizard looks like

WizardDialog wizard = new MyImportWizardDialog();
wizard.open();
wizard.getFirstPage().setName("xyz");
wizard.next();
WizardPage pageB = wizard.getSecondPage();
if(pageB instanceof MyWizardPageB1) {
    MyWizardPageB1 pageB1 = (MyWizardPageB1) pageB;
    pageB1.setXyz();
}
if(pageB instanceof MyWizardPageB2) {
    MyWizardPageB2 pageB2 = (MyWizardPageB2) pageB;
    pageB1.setZyx();
}
...

So, here are my suggestions how to improve that

1) We should get a WizardPage using WizardDialog.next() or WizardDialog.back() + maybe ImportWizardDialog.open()
2) It's not necessary to have reference to WizardDialog in WizardPage (do we really need this?). The same for pageIndex in WizardPage (WizardDialog takes care about that)
3) Each WizardPage will have a method for filling the page, something like WizardPage.fillWizardPage("name", "xyz") and method setName("xyz") will be invoked on that page

You can find the changes at https://github.com/apodhrad/reddeer/commit/6b3bbd3fa625609a291b1fe71c00ad0d6cfd4f86

Using these changes we will get the following code

WizardDialog wizard = new MyImportWizardDialog();
wizard.open().setName("xyz");
WizardPage pageB = wizard.next();
pageB.fillWizardPage("attribute", "value")

So, what you think about that? 

-- Andrej Podhradsky 
