### PR TITLE
Fix for ViewTihToolTipIsActive condition.

### DIFF
--- a/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/condition/ViewWithToolTipIsActive.java
+++ b/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/condition/ViewWithToolTipIsActive.java
@@ -22,7 +22,7 @@ public class ViewWithToolTipIsActive implements WaitCondition {
 	@Override
 	public boolean test() {
 		for (IViewReference view : WorkbenchLookup.findAllViews()) {
-			if (view.getTitle().equals(toolTip)) {
+			if (view.getPartName().equals(toolTip)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
view.getTitle() returns non-expected value (in some cases, additional information is added into tooltip string). This is fixed by changing it to view.getPartName()
