### PR TITLE
Reddeer works with TP Kepler M6

### DIFF
--- a/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Activator: org.jboss.reddeer.eclipse.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.jdt.debug.ui,
- org.junit4;bundle-version="4.8.1",
+ org.junit;bundle-version="4.11.0",
  org.jboss.reddeer.eclipse;bundle-version="0.2.0",
  org.jboss.reddeer.jface;bundle-version="0.2.0",
  org.jboss.reddeer.workbench;bundle-version="0.2.0",
@@ -21,4 +21,4 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.swt.test;bundle-version="0.2.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Import-Package: org.hamcrest
+Import-Package: org.hamcrest.core

--- a/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.workbench;bundle-version="0.2.0",
  org.apache.log4j;bundle-version="1.2.0",
  org.eclipse.swtbot.eclipse.finder;bundle-version="2.0.5",
- org.hamcrest;bundle-version="1.1.0",
+ org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.ui.workbench
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Activator: org.jboss.reddeer.jface.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.jboss.reddeer.jface;bundle-version="0.2.0",
- org.junit4;bundle-version="4.8.1",
+ org.junit;bundle-version="4.11.0",
  org.jboss.reddeer.swt;bundle-version="0.2.0",
  org.jboss.reddeer.swt.test;bundle-version="0.2.0"
 Bundle-ActivationPolicy: lazy

--- a/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.jboss.reddeer.swt;bundle-version="0.2.0",
  org.apache.log4j;bundle-version="1.2.0",
- org.hamcrest;bundle-version="1.1.0"
+ org.hamcrest.core;bundle-version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.eclipse.jface.exception,

--- a/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Activator: org.jboss.reddeer.junit.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.junit;bundle-version="4.0.0",
- org.hamcrest;bundle-version="1.1.0",
+ org.hamcrest.core;bundle-version="1.3.0",
  org.apache.log4j;bundle-version="1.2.0",
  org.apache.commons.logging;bundle-version="1.0.4"
 Bundle-ActivationPolicy: lazy

--- a/org.jboss.reddeer.parent/pom.xml
+++ b/org.jboss.reddeer.parent/pom.xml
@@ -11,8 +11,8 @@
 	<properties>
  	   	<tycho-version>0.17.0</tycho-version>  	  
 		<tychoExtrasVersion>${tycho-version}</tychoExtrasVersion>
-		<eclipse-target-site>http://download.eclipse.org/releases/kepler</eclipse-target-site>
-		<swtbot-update-site>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site</swtbot-update-site>
+		<eclipse-target-site>http://download.jboss.org/jbosstools/targetplatforms/jbosstoolstarget/4.30.5.Alpha4-SNAPSHOT/REPO</eclipse-target-site>
+		<swtbot-update-site>http://download.eclipse.org/technology/swtbot/snapshots</swtbot-update-site>
 		<platformSystemProperties></platformSystemProperties>
 	</properties>
 	

--- a/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
@@ -8,11 +8,11 @@ Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.junit4;bundle-version="4.8.1",
+ org.junit;bundle-version="4.11.0",
  org.eclipse.swtbot.eclipse.finder;bundle-version="2.0.5",
  org.jboss.reddeer.swt;bundle-version="0.2.0",
  org.jboss.reddeer.workbench;bundle-version="0.2.0",
- org.hamcrest;bundle-version="1.1.0",
+ org.hamcrest.core;bundle-version="1.3.0",
  org.apache.log4j;bundle-version="1.2.12",
  org.eclipse.core.expressions,
  org.eclipse.ui.views.log,

--- a/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swtbot.eclipse.finder;bundle-version="2.0.5",
  org.eclipse.swtbot.forms.finder;bundle-version="2.0.5",
  org.eclipse.swtbot.swt.finder;bundle-version="2.0.5",
- org.hamcrest;bundle-version="1.1.0",
+ org.hamcrest.core;bundle-version="1.3.0",
  org.apache.log4j;bundle-version="1.2.13",
  org.eclipse.swtbot.go;bundle-version="2.0.5",
  org.eclipse.swt

--- a/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.workbench,
  org.jboss.reddeer.uiforms,
  org.eclipse.swtbot.eclipse.finder,
- org.hamcrest;bundle-version="1.1.0",
- org.junit4,
+ org.hamcrest.core;bundle-version="1.3.0",
+ org.junit,
  org.apache.log4j;bundle-version="1.2.13"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.forms,
  org.jboss.reddeer.swt,
  org.eclipse.swtbot.eclipse.finder,
- org.hamcrest;bundle-version="1.1.0",
+ org.hamcrest.core;bundle-version="1.3.0",
  org.apache.log4j;bundle-version="1.2.13",
  org.eclipse.ui.forms
 Bundle-ActivationPolicy: lazy

--- a/org.jboss.reddeer.wiki.examples/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.wiki.examples/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 0.2.0.qualifier
 Require-Bundle: org.jboss.reddeer.eclipse,
  org.jboss.reddeer.jface,
  org.jboss.reddeer.junit,
- org.junit4;bundle-version="4.8.1",
+ org.junit;bundle-version="4.11.0",
  org.jboss.reddeer.swt,
  org.jboss.reddeer.workbench,
  org.eclipse.swtbot.eclipse.finder,

--- a/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.workbench;bundle-version="0.2.0",
  org.jboss.reddeer.swt;bundle-version="0.2.0",
  org.eclipse.core.runtime,
- org.junit4;bundle-version="4.8.1",
+ org.junit;bundle-version="4.11.0",
  org.jboss.reddeer.swt.test;bundle-version="0.2.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swtbot.forms.finder;bundle-version="2.0.5",
  org.eclipse.swtbot.swt.finder;bundle-version="2.0.5",
  org.jboss.reddeer.swt;bundle-version="0.2.0",
- org.hamcrest;bundle-version="1.1.0",
+ org.hamcrest.core;bundle-version="1.3.0",
  org.apache.log4j;bundle-version="1.2.13"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6


### PR DESCRIPTION
Bug (https://bugs.eclipse.org/bugs/show_bug.cgi?id=404346) makes our tests failing. Steps we need to do:
1. remove org.hamcrest in all manifest files of reddeer plugins (replace them by the correct ones, e.g. org.hamcrest.core)
2. reference to swtbot update site in parent pom (or in settings.xml) should point to the newest one (2.1.1) 
3. replace junit4 by junit in manifest file
