### PR TITLE
Wrong Text is chosen by it's index

### DIFF
--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/impl/WidgetLookup.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/impl/WidgetLookup.java
@@ -275,8 +275,7 @@ public class WidgetLookup {
 			return new ArrayList<T>();
 		
 		
-		if (!visible(parentWidget) && (!isComposite(parentWidget))) {
-				// log not visible, not composite
+		if (!visible(parentWidget)) {
 			return new ArrayList<T>();
 		}
 		


### PR DESCRIPTION
If i instantiate Text given by its index I think that wrong text is chosen.

I tried this case:

``` java
      public class MavenPreferencesDialog extends PreferencePage{

    public MavenPreferencesDialog(){
        super("Maven","User Settings");
    }

    public void setUserSettings(String pathToSettings){
        Text text = new DefaultText(1);
        System.out.println(text.getText());
    }

    }
```

The default value of this Text button is your maven settings (userhome/.m2/settings.xml). Test will not fail but result is strange - the text's text is null - this means that some other Text widget is chosen. I'm 100% sure that a while ago this worked correctly. Maybe some small mistake was created in WidgetLookup ?
