### PR TITLE
Failing ProblemsViewTests

### DIFF
--- a/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardDialog.java
+++ b/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardDialog.java
@@ -38,7 +38,8 @@ public class NewJavaProjectWizardDialog extends NewWizardDialog{
 				}
 				new WaitWhile(new ShellWithTextIsActive(shell.getText()), TimePeriod.LONG);
 			}
-		} catch (TimeoutException te) {
+		// TODO WaitWhile needs to be overwritten to throw SWTLayerException
+		} catch (RuntimeException te) {
 			log.info("Shell 'Open Associated Perspective' wasn't shown");
 		}
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);


### PR DESCRIPTION
org.jboss.reddeer.eclipse.test.ui.problems.ProblemsViewTest.testOneErrorNoWarning

Failing for the past 13 builds (Since #350 )
Took 11 sec.
add description
Error Message

No shell is available at the moment
Stacktrace

org.jboss.reddeer.swt.exception.SWTLayerException: No shell is available at the moment
    at org.jboss.reddeer.swt.impl.shell.DefaultShell.<init>(DefaultShell.java:32)
    at org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardDialog.finish(NewJavaProjectWizardDialog.java:32)
    at org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardDialog.finish(NewJavaProjectWizardDialog.java:25)
    at org.jboss.reddeer.eclipse.test.ui.problems.ProblemsViewTest.setUp(ProblemsViewTest.java:41)
    at org.jboss.reddeer.swt.test.RedDeerTest.setUpRDT(RedDeerTest.java:26)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
    at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
    at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:85)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
    at org.eclipse.ui.internal.testing.WorkbenchTestable$1.run(WorkbenchTestable.java:71)
    at java.lang.Thread.run(Thread.java:662)
Standard Output

INFO  [WorkbenchTestable][TopMenuWizardDialog] Opening wizard using top menu 
INFO  [main][MenuLookup$10] Item match:File
INFO  [main][MenuLookup$10] Item match:New  Shift+Alt+N
INFO  [main][MenuLookup$10] Item match:Other... Ctrl+N
INFO  [main][MenuLookup$4] Click on menu item: &Other...    Ctrl+N
INFO  [WorkbenchTestable][DefaultShell] Shell with title 'New' found
Java Project was found
INFO  [WorkbenchTestable][WizardDialog] Go to next wizard page
INFO  [WorkbenchTestable][AbstractButton] Click on the button &Next >
WARN  [main][AbstractSWTBot$2] Widget is not enabled: (of type 'Button' and with mnemonic 'Next >' and with style 'SWT.PUSH')
WARN  [main][AbstractSWTBot$2] Widget is not enabled: (of type 'Button' and with mnemonic 'Next >' and with style 'SWT.PUSH')
WARN  [main][AbstractSWTBot$2] Widget is not enabled: (of type 'Button' and with mnemonic 'Next >' and with style 'SWT.PUSH')
WARN  [main][AbstractSWTBot$2] Widget is not enabled: (of type 'Button' and with mnemonic 'Next >' and with style 'SWT.PUSH')
WARN  [main][AbstractSWTBot$2] Widget is not enabled: (of type 'Button' and with mnemonic 'Next >' and with style 'SWT.PUSH')
INFO  [WorkbenchTestable][AbstractText] Text set to: Test
INFO  [WorkbenchTestable][AbstractButton] Click on the button &Finish
