### PR TITLE
Upversion RedDeer to 0.3.0-SNAPSHOT

### DIFF
--- a/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Direct
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.direct
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.direct.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/org.jboss.reddeer.direct/pom.xml
+++ b/org.jboss.reddeer.direct/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Eclipse Componnet Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.eclipse.test;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.eclipse.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/org.jboss.reddeer.eclipse.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 

--- a/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Eclipse Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.eclipse
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.eclipse.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.eclipse/pom.xml
+++ b/org.jboss.reddeer.eclipse/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.examples/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.examples/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Examples
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.examples
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Require-Bundle: org.jboss.reddeer.eclipse,
  org.jboss.reddeer.jface,
  org.jboss.reddeer.junit,

--- a/org.jboss.reddeer.examples/pom.xml
+++ b/org.jboss.reddeer.examples/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.feature/feature.xml
+++ b/org.jboss.reddeer.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.3.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/org.jboss.reddeer.feature/pom.xml
+++ b/org.jboss.reddeer.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 	<build>

--- a/org.jboss.reddeer.gef/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.gef/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer GEF Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.gef
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.gef.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/org.jboss.reddeer.gef/pom.xml
+++ b/org.jboss.reddeer.gef/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JFace Componnet Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.jface.test;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.jface.test/pom.xml
+++ b/org.jboss.reddeer.jface.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JFace Componnet
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.jface
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.jface/pom.xml
+++ b/org.jboss.reddeer.jface/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.junit.test/pom.xml
+++ b/org.jboss.reddeer.junit.test/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.jboss.reddeer</groupId>
 			<artifactId>org.jboss.reddeer.junit</artifactId>
-			<version>0.2.0-SNAPSHOT</version>
+			<version>0.3.0-SNAPSHOT</version>
 			<type>eclipse-plugin</type>
 		</dependency>
 

--- a/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Support
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.junit
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.junit/pom.xml
+++ b/org.jboss.reddeer.junit/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 	

--- a/org.jboss.reddeer.parent/pom.xml
+++ b/org.jboss.reddeer.parent/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>parent</artifactId>
 	<name>Red Deer Parent POM File</name>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<properties>

--- a/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Requirements Test
 Bundle-SymbolicName: org.jboss.reddeer.requirements.test
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.requirements.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.requirements.test/pom.xml
+++ b/org.jboss.reddeer.requirements.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 

--- a/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Reddeer Requirements support
 Bundle-SymbolicName: org.jboss.reddeer.requirements
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.requirements.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.requirements/pom.xml
+++ b/org.jboss.reddeer.requirements/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 

--- a/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Selenium Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.selenium
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.redderr.bot.selenium.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/org.jboss.reddeer.selenium/pom.xml
+++ b/org.jboss.reddeer.selenium/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.site/pom.xml
+++ b/org.jboss.reddeer.site/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer SWT Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.swt.test;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.swt.test/pom.xml
+++ b/org.jboss.reddeer.swt.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 

--- a/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer SWT Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.swt
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.workbench,

--- a/org.jboss.reddeer.swt/pom.xml
+++ b/org.jboss.reddeer.swt/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer UI Component
 Bundle-SymbolicName: org.jboss.reddeer.ui;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.ui.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/org.jboss.reddeer.ui/pom.xml
+++ b/org.jboss.reddeer.ui/pom.xml
@@ -7,7 +7,7 @@
   <parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
   </parent>
   

--- a/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Red Deer UI Forms Components Test
 Bundle-SymbolicName: org.jboss.reddeer.uiforms.test;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.uiforms.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.uiforms.test/pom.xml
+++ b/org.jboss.reddeer.uiforms.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 

--- a/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Red Deer UI Forms Components
 Bundle-SymbolicName: org.jboss.reddeer.uiforms
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.uiforms.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.uiforms/pom.xml
+++ b/org.jboss.reddeer.uiforms/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Workbench Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.workbench.test;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.workbench;bundle-version="0.2.0",

--- a/org.jboss.reddeer.workbench.test/pom.xml
+++ b/org.jboss.reddeer.workbench.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 

--- a/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Workbench Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.workbench
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.jboss.reddeer.workbench/pom.xml
+++ b/org.jboss.reddeer.workbench/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
 </project>


### PR DESCRIPTION
Since we decided to retrospectively release 0.2.0 for compatible
with juno, everything in master has to move to 0.3.0-SNAPSHOT
and soon we will have a 0.3.0 release in master.
