### PR TITLE
RedDeer build failed - unable resolve org.eclipse.platform.ide

### DIFF
--- a/org.jboss.reddeer.parent/pom.xml
+++ b/org.jboss.reddeer.parent/pom.xml
@@ -117,7 +117,7 @@
 					<dependencies>
 						<dependency>
 							<type>p2-installable-unit</type>
-							<artifactId>org.eclipse.platform.ide</artifactId>
+							<artifactId>org.eclipse.platform</artifactId>
 							<version>0.0.0</version>
 						</dependency>
 						<dependency>


### PR DESCRIPTION
INFO] Red Deer Site ..................................... SUCCESS [6.695s]
[INFO] Red Deer Requirements Support ..................... SUCCESS [0.255s]
[INFO] Red Deer Requirements Tests ....................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1:02.982s
[INFO] Finished at: Thu May 23 03:06:01 EDT 2013
[INFO] Final Memory: 52M/647M
[INFO] ------------------------------------------------------------------------
[WARNING] The requested profile "hudson" could not be activated because it does not exist.
[WARNING] The requested profile "pack200" could not be activated because it does not exist.
[WARNING] The requested profile "jbosstools-nightly-staging-composite" could not be activated because it does not exist.
[WARNING] The requested profile "unified.target" could not be activated because it does not exist.
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-surefire-plugin:0.17.0:test (default-test) on project org.jboss.reddeer.swt.test: Execution default-test of goal org.eclipse.tycho:tycho-surefire-plugin:0.17.0:test failed: "No solution found because the problem is unsatisfiable.": ["Unable to satisfy dependency from tycho-extra-1369292743901 0.0.0.1369292743901 to org.eclipse.platform.ide 0.0.0.", "Unable to satisfy dependency from tycho-1369292743916 0.0.0.1369292743916 to org.eclipse.platform.ide 0.0.0.", "No solution found because the problem is unsatisfiable."] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.eclipse.tycho:tycho-surefire-plugin:0.17.0:test (default-test) on project org.jboss.reddeer.swt.test: Execution default-test of goal org.eclipse.tycho:tycho-surefire-plugin:0.17.0:test failed: "No solution found because the problem is unsatisfiable.": ["Unable to satisfy dependency from tycho-extra-1369292743901 0.0.0.1369292743901 to org.eclipse.platform.ide 0.0.0.", "Unable to satisfy dependency from tycho-1369292743916 0.0.0.1369292743916 to org.eclipse.platform.ide 0.0.0.", "No solution found because the problem is unsatisfiable."]
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:225)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-test of goal org.eclipse.tycho:tycho-surefire-plugin:0.17.0:test failed: "No solution found because the problem is unsatisfiable.": ["Unable to satisfy dependency from tycho-extra-1369292743901 0.0.0.1369292743901 to org.eclipse.platform.ide 0.0.0.", "Unable to satisfy dependency from tycho-1369292743916 0.0.0.1369292743916 to org.eclipse.platform.ide 0.0.0.", "No solution found because the problem is unsatisfiable."]
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:110)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
    ... 19 more
Caused by: java.lang.RuntimeException: "No solution found because the problem is unsatisfiable.": ["Unable to satisfy dependency from tycho-extra-1369292743901 0.0.0.1369292743901 to org.eclipse.platform.ide 0.0.0.", "Unable to satisfy dependency from tycho-1369292743916 0.0.0.1369292743916 to org.eclipse.platform.ide 0.0.0.", "No solution found because the problem is unsatisfiable."]
    at org.eclipse.tycho.p2.resolver.AbstractResolutionStrategy.newResolutionException(AbstractResolutionStrategy.java:81)
    at org.eclipse.tycho.p2.resolver.ProjectorResolutionStrategy.resolve(ProjectorResolutionStrategy.java:88)
    at org.eclipse.tycho.p2.resolver.AbstractResolutionStrategy.resolve(AbstractResolutionStrategy.java:58)
    at org.eclipse.tycho.p2.impl.resolver.P2ResolverImpl.resolveDependencies(P2ResolverImpl.java:122)
    at org.eclipse.tycho.p2.impl.resolver.P2ResolverImpl.resolveDependencies(P2ResolverImpl.java:78)
    at org.eclipse.tycho.p2.resolver.P2TargetPlatformResolver.doResolvePlatform(P2TargetPlatformResolver.java:373)
    at org.eclipse.tycho.p2.resolver.P2TargetPlatformResolver.resolveDependencies(P2TargetPlatformResolver.java:350)
    at org.eclipse.tycho.surefire.TestMojo.createEclipseInstallation(TestMojo.java:593)
    at org.eclipse.tycho.surefire.TestMojo.execute(TestMojo.java:559)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
    ... 20 more
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :org.jboss.reddeer.swt.test
Build step 'Invoke top-level Maven targets' marked build as failure
Xvfb stopping
Window manager warning: Lost connection to the display ':1';
most likely the X server was shut down or you killed/destroyed
the window manager.
Archiving artifacts
Recording test results
Description set: 
Sending e-mails to: jpeterka@redhat.com jbosstools-builds@lists.jboss.org mmalina@redhat.com
Notifying upstream projects of job completion
Finished: FAILURE
