### PR TITLE
LogView test is failing sometimes

### DIFF
--- a/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/log/LogViewTest.java
+++ b/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/log/LogViewTest.java
@@ -76,16 +76,12 @@ public class LogViewTest extends RedDeerTest{
 		assertTrue("No OK messages found!", !messages.isEmpty());
 		
 		//test OK Message no.1
-		assertTrue(messages.get(1).getSeverity() == IStatus.OK);
-		assertTrue(messages.get(1).getPlugin().equals(OK_ID_1));
-		assertTrue(messages.get(1).getMessage().equals(OK_MESSAGE_1));
-		assertTrue(messages.get(1).getStackTrace().equals("An exception stack trace is not available."));
-		
+		assertTrue(messageIsAvailable(messages, IStatus.OK, OK_ID_1,
+				OK_MESSAGE_1, "An exception stack trace is not available."));
+
 		//test OK Message no.2
-		assertTrue(messages.get(0).getSeverity() == IStatus.OK);
-		assertTrue(messages.get(0).getPlugin().equals(OK_ID_2));
-		assertTrue(messages.get(0).getMessage().equals(OK_MESSAGE_2));
-		assertTrue(messages.get(0).getStackTrace().contains(OK_STACK_2));
+		assertTrue(messageIsAvailable(messages, IStatus.OK, OK_ID_2,
+				OK_MESSAGE_2, OK_STACK_2));		
 	}
 	
 	@Test
@@ -96,16 +92,12 @@ public class LogViewTest extends RedDeerTest{
 		assertTrue("No INFO messages found!", !messages.isEmpty());
 		
 		//test INFO Message no.1
-		assertTrue(messages.get(1).getSeverity() == IStatus.INFO);
-		assertTrue(messages.get(1).getPlugin().equals(INFO_ID_1));
-		assertTrue(messages.get(1).getMessage().equals(INFO_MESSAGE_1));
-		assertTrue(messages.get(1).getStackTrace().equals("An exception stack trace is not available."));
+		assertTrue(messageIsAvailable(messages, IStatus.INFO, INFO_ID_1,
+				INFO_MESSAGE_1, "An exception stack trace is not available."));
 				
 		//test INFO Message no.2
-		assertTrue(messages.get(0).getSeverity() == IStatus.INFO);
-		assertTrue(messages.get(0).getPlugin().equals(INFO_ID_2));
-		assertTrue(messages.get(0).getMessage().equals(INFO_MESSAGE_2));
-		assertTrue(messages.get(0).getStackTrace().contains(INFO_STACK_2));
+		assertTrue(messageIsAvailable(messages, IStatus.INFO, INFO_ID_2,
+				INFO_MESSAGE_2, INFO_STACK_2));
 	}
 	
 	@Test
@@ -116,16 +108,12 @@ public class LogViewTest extends RedDeerTest{
 		assertTrue("No WARNING messages found!", !messages.isEmpty());
 		
 		//test WARNING Message no.1
-		assertTrue(messages.get(1).getSeverity() == IStatus.WARNING);
-		assertTrue(messages.get(1).getPlugin().equals(WARNING_ID_1));
-		assertTrue(messages.get(1).getMessage().equals(WARNING_MESSAGE_1));
-		assertTrue(messages.get(1).getStackTrace().contains(WARNING_STACK_1));
+		assertTrue(messageIsAvailable(messages, IStatus.WARNING, WARNING_ID_1,
+				WARNING_MESSAGE_1, WARNING_STACK_1));
 				
 		//test WARNING Message no.2
-		assertTrue(messages.get(0).getSeverity() == IStatus.WARNING);
-		assertTrue(messages.get(0).getPlugin().equals(WARNING_ID_2));
-		assertTrue(messages.get(0).getMessage().equals(WARNING_MESSAGE_2));
-		assertTrue(messages.get(0).getStackTrace().contains(WARNING_STACK_2));
+		assertTrue(messageIsAvailable(messages, IStatus.WARNING, WARNING_ID_2,
+				WARNING_MESSAGE_2, WARNING_STACK_2));
 	}
 	
 	@Test
@@ -136,16 +124,22 @@ public class LogViewTest extends RedDeerTest{
 		assertTrue("No ERROR messages found!", !messages.isEmpty());
 		
 		//test ERROR Message no.1
-		assertTrue(messages.get(1).getSeverity() == IStatus.ERROR);
-		assertTrue(messages.get(1).getPlugin().equals(ERROR_ID_1));
-		assertTrue(messages.get(1).getMessage().equals(ERROR_MESSAGE_1));
-		assertTrue(messages.get(1).getStackTrace().contains(ERROR_STACK_1));
-						
+		assertTrue(messageIsAvailable(messages, IStatus.ERROR, ERROR_ID_1,
+				ERROR_MESSAGE_1, ERROR_STACK_1));
+				
 		//test ERROR Message no.2
-		assertTrue(messages.get(0).getSeverity() == IStatus.ERROR);
-		assertTrue(messages.get(0).getPlugin().equals(ERROR_ID_2));
-		assertTrue(messages.get(0).getMessage().equals(ERROR_MESSAGE_2));
-		assertTrue(messages.get(0).getStackTrace().contains(ERROR_STACK_2));
+		assertTrue(messageIsAvailable(messages, IStatus.ERROR, ERROR_ID_2,
+				ERROR_MESSAGE_2, ERROR_STACK_2));
+	}
+
+	private boolean messageIsAvailable(List<LogMessage> messages, int severity, String plugin, String message,String stackTrace) {
+		for (LogMessage m : messages) {
+			if (m.getSeverity() == severity && m.getPlugin().equals(plugin) && m.getMessage().equals(message)) {
+				return true;
+			}
+		}
+		
+		return false;
 	}
 	
 }


### PR DESCRIPTION
Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 37.97 sec <<< FAILURE!
getInfoMessage(org.jboss.reddeer.eclipse.test.ui.views.log.LogViewTest)  Time elapsed: 6.573 secgetErrorMessage(org.jboss.reddeer.eclipse.test.ui.views.log.LogViewTest)  Time elapse$
java.lang.AssertionError
        at org.junit.Assert.fail(Assert.java:86)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at org.junit.Assert.assertTrue(Assert.java:52)
        at org.jboss.reddeer.eclipse.test.ui.views.log.LogViewTest.getErrorMessage(LogViewTest.java:140)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
        at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
        at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
        at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
        at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
        at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:85)
        at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
        at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:72)
        at java.lang.Thread.run(Thread.java:724)
getWarningMessage(org.jboss.reddeer.eclipse.test.ui.views.log.LogViewTest)  Time elapsed: 25.118 secgetOKMessage(org.jboss.reddeer.eclipse.test.ui.views.log.LogViewTest)  Time elaps$
