### PR TITLE
Add switch to pause failing test

### DIFF
--- a/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -16,10 +16,12 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,
  lib/commons-beanutils-core-1.8.3.jar
 Export-Package: org.jboss.reddeer.junit,
+ org.jboss.reddeer.junit.internal.configuration;x-friends:="org.jboss.reddeer.requirements.test",
+ org.jboss.reddeer.junit.internal.requirement;x-friends:="org.jboss.reddeer.requirements.test",
+ org.jboss.reddeer.junit.internal.runner;x-friends:="org.jboss.reddeer.requirements.test",
  org.jboss.reddeer.junit.requirement,
  org.jboss.reddeer.junit.requirement.inject,
  org.jboss.reddeer.junit.runner,
- org.jboss.reddeer.junit.internal.runner;x-friends:=org.jboss.reddeer.requirements.test,
- org.jboss.reddeer.junit.internal.configuration;x-friends:=org.jboss.reddeer.requirements.test,
- org.jboss.reddeer.junit.internal.requirement;x-friends:=org.jboss.reddeer.requirements.test
+ org.jboss.reddeer.junit.watcher
 Eclipse-RegisterBuddy: org.apache.log4j
+Import-Package: org.jboss.reddeer.swt.util

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/ExecutionSetting.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/ExecutionSetting.java
@@ -1,0 +1,55 @@
+package org.jboss.reddeer.junit;
+
+
+/**
+ * Recognized RedDeer test execution parameters 
+ * @author Jiri Peterka
+ *
+ */
+public class ExecutionSetting {
+	private static ExecutionSetting instance;
+	private boolean debugEnabled = true;
+	private boolean pauseFailedTest = false; 
+	
+	
+	/**
+	 * Provides ExecutionSetting instance
+	 * @return instance
+	 */
+	public static ExecutionSetting getInstance() {
+		if (instance == null) {
+			instance = new ExecutionSetting();
+			instance.debugEnabled = instance.readSystemProperty("logDebug",true);
+			instance.pauseFailedTest = instance.readSystemProperty("pauseFailedTest",false);
+		}
+		return instance;
+	}
+	
+	private boolean readSystemProperty(String var, boolean b) {
+		String val = System.getProperty(var);
+		if ((val == null) || (!val.equals("false") && (!val.equals("true")))) {
+			return b;
+		} else return Boolean.parseBoolean(val);		
+	}
+
+	private ExecutionSetting() {
+		
+	}
+
+	/**
+	 * isDebugEnabled getter
+	 * @return true if -DlogDebug=true (default), false otherwise
+	 */
+	public boolean isDebugEnabled() {
+		return debugEnabled;
+	}
+	
+	/**
+	 * pauseFailedTest getter
+	 * @return true if -DpauseFailingTest=true, false otherwise (default)
+	 */	
+	public boolean isPauseFailedTest() {
+		return pauseFailedTest;
+	}
+	
+}

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/watcher/RedDeerWatchdog.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/watcher/RedDeerWatchdog.java
@@ -1,0 +1,32 @@
+package org.jboss.reddeer.junit.watcher;
+
+import java.io.IOException;
+
+import org.apache.log4j.Logger;
+import org.jboss.reddeer.junit.ExecutionSetting;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/**
+ * RedDeer Watchdog hooks executed tests and performs operations when if test
+ * failes
+ * 
+ * @author Jiri Peterka
+ * 
+ */
+public class RedDeerWatchdog extends TestWatcher {
+	Logger log = Logger.getLogger(RedDeerWatchdog.class);
+
+	@Override
+	protected void failed(Throwable e, Description description) {
+		if (ExecutionSetting.getInstance().isPauseFailedTest()) {
+			try {
+				log.info("Test execution is paused because of failing test, press [Enter] to continue");
+				System.in.read();
+			} catch (IOException ex) {
+				log.error(ex.getMessage());
+			}
+		}
+
+	}
+}

--- a/org.jboss.reddeer.parent/pom.xml
+++ b/org.jboss.reddeer.parent/pom.xml
@@ -14,7 +14,8 @@
 		<eclipse-target-site>http://download.eclipse.org/releases/kepler</eclipse-target-site>
 		<swtbot-update-site>http://download.eclipse.org/technology/swtbot/snapshots</swtbot-update-site>
 		<platformSystemProperties></platformSystemProperties>
-		<log.debug>true</log.debug>
+		<logDebug>true</logDebug>
+		<pauseFailedTest>false</pauseFailedTest>
 	</properties>
 	
 	<modules>
@@ -113,7 +114,7 @@
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
 					<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
-					<argLine>-Dlog.debug=${log.debug} ${platformSystemProperties} -XX:MaxPermSize=512m</argLine>
+					<argLine>-DlogDebug=${log.debug} -DpauseFailedTest=${pauseFailedTest} ${platformSystemProperties} -XX:MaxPermSize=512m</argLine>
 					<product>org.eclipse.platform.ide</product>
 					<application>org.eclipse.ui.ide.workbench</application>
 					<dependencies>

--- a/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/RedDeerTest.java
+++ b/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/RedDeerTest.java
@@ -5,10 +5,13 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 import org.eclipse.ui.IViewReference;
+import org.jboss.reddeer.junit.ExecutionSetting;
+import org.jboss.reddeer.junit.watcher.RedDeerWatchdog;
 import org.jboss.reddeer.swt.lookup.impl.WorkbenchLookup;
 import org.jboss.reddeer.swt.util.Display;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 /**
  * Parent test for each test of Red Deer
  * @author Vlado Pakan
@@ -18,6 +21,9 @@ import org.junit.Before;
  */
 public class RedDeerTest {
 
+	@Rule 
+    public RedDeerWatchdog rule = new RedDeerWatchdog();
+	
 	Logger log = Logger.getLogger(RedDeerTest.class);
 	
 	@Before
@@ -33,12 +39,10 @@ public class RedDeerTest {
 		console.setName("console");
 		String PATTERN = "%-5p [%t][%C{1}] %m%n";
 		console.setLayout(new PatternLayout(PATTERN));
-		// if you want to enable just add vm argument -Dlog.debug=true
-		String debugProp = System.getProperty("log.debug");
-		if (debugProp != null && debugProp.equalsIgnoreCase("false")) {
-			console.setThreshold(Level.INFO);
-		} else {
+		if (ExecutionSetting.getInstance().isPauseFailedTest()) {			
 			console.setThreshold(Level.DEBUG);
+		} else {
+			console.setThreshold(Level.INFO);
 		}
 		console.activateOptions();
 		Logger.getRootLogger().addAppender(console);


### PR DESCRIPTION
Currently IDE tests continue and after last test IDE is closed no matter what. It could be handy to have support to pause test execution after test fails.
