### PR TITLE
Tests fail after adding org.eclipse.jdt.feature.group

### DIFF
--- a/org.jboss.reddeer.parent/pom.xml
+++ b/org.jboss.reddeer.parent/pom.xml
@@ -139,7 +139,7 @@
 						</dependency>
 						<dependency>
 							<type>p2-installable-unit</type>
-							<artifactId>org.eclipse.jdt.feature.group</artifactId>
+							<artifactId>org.eclipse.jdt.junit</artifactId>
 							<version>0.0.0</version>
 						</dependency>
 					</dependencies>


### PR DESCRIPTION
After adding org.eclipse.jdt.feature.group as a dependency in parent pom some tests fail (requirement tests).
