### PR TITLE
Fix shell waiting in DriverDefinitionWizard

### DIFF
--- a/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/org.jboss.reddeer.eclipse.test/pom.xml
@@ -12,7 +12,63 @@
 		<version>0.4.0-SNAPSHOT</version>
 		<relativePath>../org.jboss.reddeer.parent/pom.xml</relativePath>
 	</parent>
-	
+
+	<dependencies>
+		<dependency>
+			<groupId>hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<version>1.8.0.10</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.8</version>
+				<executions>
+					<execution>
+						<id>copy-hsqldb-driver</id>
+						<phase>package</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>hsqldb</groupId>
+									<artifactId>hsqldb</artifactId>
+									<version>1.8.0.10</version>
+									<type>jar</type>
+									<outputDirectory>${project.build.directory}/lib</outputDirectory>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<configuration>
+					<dependencies combine.children="append">
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.datatools.enablement.hsqldb.ui</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.datatools.enablement.hsqldb.dbdefinition</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+					</dependencies>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 	<profiles>
 		<profile>
 			<id>add-jdt-feature</id>

--- a/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/datatools/ui/DriverDefinitionTest.java
+++ b/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/datatools/ui/DriverDefinitionTest.java
@@ -1,0 +1,33 @@
+package org.jboss.reddeer.eclipse.test.datatools.ui;
+
+import java.io.File;
+
+import org.jboss.reddeer.eclipse.datatools.ui.preference.DriverDefinitionPreferencePage;
+import org.jboss.reddeer.eclipse.datatools.ui.wizard.DriverDefinitionPage;
+import org.jboss.reddeer.eclipse.datatools.ui.wizard.DriverDefinitionWizard;
+import org.jboss.reddeer.swt.impl.table.DefaultTable;
+import org.jboss.reddeer.swt.test.RedDeerTest;
+import org.junit.Test;
+
+/**
+ * 
+ * @author Andrej Podhradsky (andrej.podhradsky@gmail.com)
+ * 
+ */
+public class DriverDefinitionTest extends RedDeerTest {
+
+	@Test
+	public void driverDefinitionTest() {
+		DriverDefinitionPreferencePage preferencePage = new DriverDefinitionPreferencePage();
+		preferencePage.open();
+		DriverDefinitionWizard wizard = preferencePage.addDriverDefinition();
+		DriverDefinitionPage page = wizard.getFirstPage();
+		page.selectDriverTemplate("HSQLDB JDBC Driver", "1.8");
+		page.setName("Test HSLQDB Driver");
+		page.addDriverLibrary(new File("target/lib/hsqldb-1.8.0.10.jar").getAbsolutePath());
+		wizard.finish();
+		// test if a driver was successfully created
+		new DefaultTable().getItem("Test HSLQDB Driver");
+		preferencePage.ok();
+	}
+}

--- a/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/DriverDefinitionWizard.java
+++ b/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/DriverDefinitionWizard.java
@@ -3,8 +3,10 @@ package org.jboss.reddeer.eclipse.datatools.ui.wizard;
 import org.jboss.reddeer.eclipse.datatools.ui.DriverDefinition;
 import org.jboss.reddeer.eclipse.datatools.ui.DriverTemplate;
 import org.jboss.reddeer.eclipse.jface.wizard.WizardDialog;
+import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.swt.impl.button.PushButton;
-import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.jboss.reddeer.swt.wait.WaitWhile;
 
 /**
  * Wizard for creating a new driver definition.
@@ -37,7 +39,7 @@ public class DriverDefinitionWizard extends WizardDialog {
 	@Override
 	public void finish() {
 		new PushButton("OK").click();
-		new DefaultShell("New Driver Definition");
+		new WaitWhile(new ShellWithTextIsActive("New Driver Definition"), TimePeriod.NORMAL);
 	}
 
 }


### PR DESCRIPTION
There was a mistake by changing 

new WaitWhile(new ShellWithTextIsActive("New Driver Definition"),TimePeriod.NORMAL);

by 

new DefaultShell("New Driver Definition");

The second one is used for WaitUntil. The solution is to get back WaitWhile.
