### PR TITLE
Unstable tests on Windows 

### DIFF
--- a/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardDialog.java
+++ b/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardDialog.java
@@ -33,7 +33,8 @@ public class NewJavaProjectWizardDialog extends NewWizardDialog{
 		final String openAssociatedPerspectiveShellText = "Open Associated Perspective?";
 		try {
 			new WaitUntil(new ShellWithTextIsActive(openAssociatedPerspectiveShellText),
-				TimePeriod.getCustom(20));
+				TimePeriod.getCustom(20),false);
+			// Try to find open perspective test
 			DefaultShell shell = new DefaultShell(openAssociatedPerspectiveShellText);
 			if (openAssociatedPerspective) {
 				new PushButton("Yes").click();

--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/AbstractWait.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/AbstractWait.java
@@ -49,7 +49,8 @@ public abstract class AbstractWait {
 			boolean throwRuntimeException) {
 		this.timeout = timeout;
 		this.throwWaitTimeoutExpiredException = throwRuntimeException;
-		log.info("Waiting with condition: " + condition.description()
+		log.info(description()
+				+ "\n  Condition=" + condition.description()
 				+ "\n  Timeout=" + timeout.getSeconds() + " seconds"
 				+ "\n  Delay= " + AbstractWait.WAIT_DELAY + " milliseconds"
 				+ "\n  Throw WaitTimeoutExpiredException="

--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/WaitUntil.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/WaitUntil.java
@@ -1,5 +1,6 @@
 package org.jboss.reddeer.swt.wait;
 
+import org.apache.log4j.Logger;
 import org.jboss.reddeer.swt.condition.WaitCondition;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException;
@@ -12,6 +13,7 @@ import org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException;
  * 
  */
 public class WaitUntil extends AbstractWait {
+	private final Logger log = Logger.getLogger(this.getClass());
 	/**
 	 * Waits until condition is fulfilled with default timeout
 	 * Throws WaitTimeoutExpiredException when timeout had expired
@@ -58,7 +60,8 @@ public class WaitUntil extends AbstractWait {
 				if (condition.test())
 					return;
 			} catch (Throwable e) {
-				// do nothing
+				log.warn("Error during evaluating wait condition " + condition.description() 
+					+ " " + e);
 			}
 			sleep(AbstractWait.WAIT_DELAY);
 			if (System.currentTimeMillis() > limit) {

--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/WaitWhile.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/WaitWhile.java
@@ -72,7 +72,8 @@ public class WaitWhile extends AbstractWait {
 				if (!condition.test())
 					return;
 			} catch (Throwable e) {
-				// do nothing
+				log.warn("Error during evaluating wait condition " + condition.description() 
+						+ " " + e);
 			}
 			sleep(AbstractWait.WAIT_DELAY);
 			if (System.currentTimeMillis() > limit) {


### PR DESCRIPTION
Open Associated Perspective shell is messing test execution, see RedDeer_master_matrix/151/jdk=sunjdk1.6,label=stable-windows/#showFailuresLink
