### PR TITLE
View is sometimes not opened

### DIFF
--- a/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/view/View.java
+++ b/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/view/View.java
@@ -208,7 +208,7 @@ public abstract class View extends WorkbenchPart{
 						.getActiveWorkbenchWindow().getActivePage()
 						.getViewReferences();
 				for (IViewReference iViewReference : views) {
-					if (iViewReference.getTitle().matches(title + ".*")) {
+					if (iViewReference.getTitle().equals(title)) {
 						return iViewReference.getView(false);
 					}
 				}


### PR DESCRIPTION
Assume we have the following views:

RedDeer SWT
-> RedDeer SWT
-> RedDeer SWT Controls

At first, open RedDeer SWT > RedDeer SWT Controls - fine, it works. 
Then, try to open RedDeer SWT > RedDeer SWT (without 'Controls'). The current implementation tries to look if it is opened by regex

iViewReference.getTitle().matches(title + ".*") // View.java:211

Do you see where's the problem? 

"RedDeer SWT Controls" matches "RedDeer SWT" + ".*"

and RedDeer SWT > RedDeer SWT is not opened.
