### PR TITLE
Add TaskRepository view to support for Mylyn tests

### DIFF
--- a/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/view/TaskRepositoriesViewTest.java
+++ b/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/view/TaskRepositoriesViewTest.java
@@ -1,0 +1,42 @@
+package org.jboss.reddeer.eclipse.test.mylyn.tasks.ui.view;
+
+import java.util.List;
+
+import org.jboss.reddeer.eclipse.mylyn.tasks.ui.view.TaskRepositoriesView;
+import org.jboss.reddeer.eclipse.mylyn.tasks.ui.view.TaskRepository;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.tree.DefaultTree;
+import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.jboss.reddeer.swt.test.RedDeerTest;
+import org.jboss.reddeer.swt.wait.AbstractWait;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * 
+ * @author ldimaggi
+ *
+ */
+public class TaskRepositoriesViewTest extends RedDeerTest {
+
+	@Test
+	public void getRepoTest() {
+		
+	TaskRepositoriesView view = new TaskRepositoriesView();	
+	
+	new ShellMenu("Window", "Show View", "Other...").select();
+	DefaultTreeItem taskRepositories = new DefaultTreeItem ("Mylyn", "Task Repositories");
+	taskRepositories.select();	
+	
+	new PushButton("OK").click();
+			
+	AbstractWait.sleep(TimePeriod.NORMAL.getSeconds());
+	DefaultTree RepoTree = new DefaultTree();
+	List<TreeItem> repoItems = RepoTree.getAllItems();
+	
+	assertFalse ("repos are found", repoItems.isEmpty());
+	}	
+}

--- a/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/view/TaskRepositoryTest.java
+++ b/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/view/TaskRepositoryTest.java
@@ -1,0 +1,62 @@
+package org.jboss.reddeer.eclipse.test.mylyn.tasks.ui.view;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.reddeer.eclipse.mylyn.tasks.ui.view.TaskRepositoriesView;
+import org.jboss.reddeer.eclipse.mylyn.tasks.ui.view.TaskRepository;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.tree.DefaultTree;
+import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.jboss.reddeer.swt.test.RedDeerTest;
+import org.jboss.reddeer.swt.wait.AbstractWait;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * 
+ * @author ldimaggi
+ * 
+ */
+public class TaskRepositoryTest extends RedDeerTest {
+
+	@Test
+	public void getRepoTest() {
+
+		TaskRepositoriesView view = new TaskRepositoriesView();
+
+		new ShellMenu("Window", "Show View", "Other...").select();
+		DefaultTreeItem taskRepositories = new DefaultTreeItem("Mylyn",
+				"Task Repositories");
+		taskRepositories.select();
+		new PushButton("OK").click();
+
+		AbstractWait.sleep(TimePeriod.NORMAL.getSeconds());
+		DefaultTree RepoTree = new DefaultTree();
+		List<TreeItem> repoItems = RepoTree.getAllItems();
+
+		assertFalse("repos are found", repoItems.isEmpty());
+		
+		ArrayList<String> repoList = new ArrayList<String>();
+		int i = 0;
+		for (TreeItem item : repoItems) {
+			repoList.add(i++, item.getText());
+		}
+		int elementIndex = repoList.indexOf("Red Hat Bugzilla");
+
+		TaskRepository testRepo = new TaskRepository(repoItems.get(elementIndex));
+		assertTrue("repo name " + testRepo.getName() + " is empty", testRepo.getName().equals("Red Hat Bugzilla"));
+		
+		try {
+			testRepo.open();
+		}
+		catch (UnsupportedOperationException U) {
+			
+		}
+		
+	}
+}

--- a/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/wizards/NewRepositoryWizardTest.java
+++ b/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/wizards/NewRepositoryWizardTest.java
@@ -1,0 +1,24 @@
+package org.jboss.reddeer.eclipse.test.mylyn.tasks.ui.wizards;
+
+import org.jboss.reddeer.eclipse.mylyn.tasks.ui.wizards.NewRepositoryWizard;
+import org.jboss.reddeer.swt.test.RedDeerTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 
+ * @author ldimaggi
+ * 
+ */
+public class NewRepositoryWizardTest extends RedDeerTest {
+
+	@Test
+	public void getWizardTest() {
+		
+		NewRepositoryWizard theWizard = new NewRepositoryWizard();
+		theWizard.open();
+		assertTrue ("the index is 1", new Integer (theWizard.getPageIndex()).equals(1));
+	
+	}
+}

--- a/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/ide/RepoConnectionDialogTest.java
+++ b/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/ide/RepoConnectionDialogTest.java
@@ -1,0 +1,61 @@
+package org.jboss.reddeer.eclipse.test.ui.ide;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.reddeer.eclipse.mylyn.tasks.ui.wizards.NewRepositoryWizard;
+import org.jboss.reddeer.eclipse.ui.ide.RepoConnectionDialog;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.impl.text.LabeledText;
+import org.jboss.reddeer.swt.impl.tree.DefaultTree;
+import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.jboss.reddeer.swt.test.RedDeerTest;
+import org.jboss.reddeer.swt.wait.AbstractWait;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 
+ * @author ldimaggi
+ * 
+ */
+public class RepoConnectionDialogTest extends RedDeerTest {
+
+	@Test
+	public void getDialogTest() {
+		
+		new ShellMenu("Window", "Show View", "Other...").select();		
+		DefaultTreeItem taskRepositories = new DefaultTreeItem ("Mylyn", "Task Repositories");
+		taskRepositories.select();		
+		new PushButton("OK").click();
+				
+		AbstractWait.sleep(TimePeriod.NORMAL.getSeconds());
+		
+		DefaultTree RepoTree = new DefaultTree();
+		List<TreeItem> repoItems = RepoTree.getAllItems();
+		
+		ArrayList<String> repoList = new ArrayList<String>();
+		int i = 0;
+		for (TreeItem item : repoItems) {
+			repoList.add(i++, item.getText());
+		}
+		int elementIndex = repoList.indexOf("Red Hat Bugzilla");
+		
+		repoItems.get(elementIndex).select();	
+		new ShellMenu("File", "Properties").select();  
+		
+		RepoConnectionDialog theRepoDialog = new RepoConnectionDialog();
+		assertTrue ("Properties title matches", theRepoDialog.getText().equals("Properties for Task Repository"));
+		
+		theRepoDialog.validateSettings();
+		assertTrue("Repo Connection Properties Invalid", new LabeledText("Bugzilla Repository Settings").getText().contains("Repository is valid"));
+	
+		theRepoDialog.close();
+		
+	}
+}

--- a/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
+++ b/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
@@ -1,0 +1,77 @@
+package org.jboss.reddeer.eclipse.mylyn.tasks.ui.view;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
+
+//import org.jboss.reddeer.eclipse.ui.ide.NewRepositoryWizard;  
+import org.jboss.reddeer.eclipse.mylyn.tasks.ui.wizards.NewRepositoryWizard;
+
+//import org.jboss.reddeer.eclipse.wst.server.ui.wizard.NewServerWizardDialog;
+import org.jboss.reddeer.swt.api.Tree;
+import org.jboss.reddeer.swt.api.TreeItem;
+//import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.impl.menu.ContextMenu;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.impl.tree.DefaultTree;
+//import org.jboss.reddeer.swt.wait.TimePeriod;
+//import org.jboss.reddeer.swt.wait.WaitUntil;
+import org.jboss.reddeer.workbench.view.View;
+
+
+/**
+ * Represents the TaskRepositories view. 
+ *  
+ * @author 
+ *
+ */
+public class TaskRepositoriesView extends View {
+	
+	public static final String TITLE = "Task Repositories";
+
+	private static final Logger log = Logger.getLogger(TaskRepositoriesView.class);
+	
+	public TaskRepositoriesView() {
+		super(TITLE);
+	}
+
+	public NewRepositoryWizard newTaskRepositories(){
+		log.info("Creating new repository");
+		open();
+		new ContextMenu("New","Add Task Repository...").select();
+		new DefaultShell("Add Task Repository...");
+		return new NewRepositoryWizard();
+	}
+
+	public List<TaskRepository> getTaskRepositories(){
+		List<TaskRepository> repositories = new ArrayList<TaskRepository>();
+
+		Tree tree;
+		try {
+			tree = getRepositoriesTree();
+		} catch (SWTLayerException e){
+			return new ArrayList<TaskRepository>();
+		}
+		for (TreeItem item : tree.getItems()){
+			repositories.add(new TaskRepository(item));
+		}
+		return repositories;
+	}
+
+	public TaskRepository getTaskRepository(String name){
+		for (TaskRepository repository : getTaskRepositories()){
+			if (repository.getName().equals(name)){
+				return repository;
+			}
+		}
+		throw new EclipseLayerException("There is no repository with name " + name);
+	}
+
+	protected Tree getRepositoriesTree(){
+		open();
+		return new DefaultTree();
+	}
+}

--- a/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepository.java
+++ b/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepository.java
@@ -1,0 +1,74 @@
+package org.jboss.reddeer.eclipse.mylyn.tasks.ui.view;
+
+import org.apache.log4j.Logger;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.condition.JobIsRunning;
+import org.jboss.reddeer.swt.condition.WaitCondition;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.menu.ContextMenu;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.jboss.reddeer.swt.wait.WaitUntil;
+import org.jboss.reddeer.swt.wait.WaitWhile;
+
+	/**
+	 * Represents a TaskRepository on {@link TaskRepositoriesView}. 
+	 * 
+	 * @author ldimaggi
+	 * 
+	 */
+	public class TaskRepository {
+
+		private static final TimePeriod TIMEOUT = TimePeriod.VERY_LONG;
+
+		private static final Logger log = Logger.getLogger(TaskRepository.class);
+		
+		private TreeItem treeItem;
+
+		public TaskRepository(TreeItem treeItem) {
+			this.treeItem = treeItem;
+		}
+
+		public void open() {
+			throw new UnsupportedOperationException();
+		}
+
+		public void delete() {
+			delete(false);
+		}
+
+		public void delete(boolean stopFirst) {
+			log.info("Deleting Repository");
+			select();
+			new ContextMenu("Delete").select();	
+			new PushButton("OK").click();
+			new WaitUntil(new TreeItemIsDisposed(treeItem), TIMEOUT);
+			new WaitWhile(new JobIsRunning(), TIMEOUT);
+		}
+
+		protected void select() {
+			treeItem.select();
+		}
+
+		public String getName(){
+			return treeItem.getText();
+		}
+
+		private class TreeItemIsDisposed implements WaitCondition {
+
+			private TreeItem treeItem;
+
+			public TreeItemIsDisposed(TreeItem treeItem) {
+				this.treeItem = treeItem;
+			}
+
+			@Override
+			public boolean test() {
+				return treeItem.isDisposed();
+			}
+
+			@Override
+			public String description() {
+				return "Repository tree item is disposed";
+			}
+		}
+	}

--- a/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/wizards/NewRepositoryWizard.java
+++ b/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/wizards/NewRepositoryWizard.java
@@ -1,0 +1,17 @@
+package org.jboss.reddeer.eclipse.mylyn.tasks.ui.wizards;
+
+import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
+
+/**
+ * Represents new file creation wizard dialog (General -> File)
+ * 
+ * @author ldimaggi
+ *
+ */
+public class NewRepositoryWizard extends NewWizardDialog {
+
+	public NewRepositoryWizard() {
+		super("General", "File");
+	}
+
+}

--- a/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/RepoConnectionDialog.java
+++ b/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/RepoConnectionDialog.java
@@ -1,0 +1,68 @@
+package org.jboss.reddeer.eclipse.ui.ide;
+
+import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.wait.AbstractWait;
+import org.jboss.reddeer.swt.wait.WaitWhile;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+
+/**
+ * Represents Quick Fix dialog
+ * 
+ * @author ldimaggi
+ *
+ */
+public class RepoConnectionDialog extends DefaultShell {
+
+	public static final String TITLE = "Properties for Task Repository";
+	
+	/**
+	 * Open QuickFix dialog and set focus on it
+	 */
+	public RepoConnectionDialog() {
+		super(TITLE);
+	}
+	
+	/**
+	 * Press Select All button
+	 */
+	public void selectAll() {
+		new PushButton("Select All").click();
+	}
+	
+	/**
+	 * Press Deselect All button
+	 */
+	public void deselectAll() {
+		new PushButton("Deselect All").click();
+	}
+	
+	/**
+	 * Press Cancel button
+	 */
+	public void cancel() {
+		new PushButton("Cancel").click();
+		new WaitWhile(new ShellWithTextIsActive(TITLE));
+	}
+	
+	/**
+	 * Press Finish button
+	 */
+	public void finish() {
+		new PushButton("Finish").click();
+		new WaitWhile(new ShellWithTextIsActive(TITLE));
+	}
+	
+	/**
+	 * Press Validate button
+	 */
+	public void validateSettings() {
+		PushButton validate = new PushButton("Validate Settings");
+		validate.click();
+		while (!validate.isEnabled()) {
+			AbstractWait.sleep(TimePeriod.NORMAL.getSeconds());
+		}
+	}
+	
+}


### PR DESCRIPTION
To remove the existing Mylyn tests' dependencies on checking for view name strings - add these classes:

org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java

org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepository.java

org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/wizards/NewRepositoryWizard.java

org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/RepoConnectionDialog.java
