### PR TITLE
Logger has to write full stacktrace of exception to log not just [[Ljava.lang.StackTraceElement;@c01c7d1

### DIFF
--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/logging/Logger.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/logging/Logger.java
@@ -86,7 +86,8 @@ public class Logger {
 	 * @param t throwable
 	 */
 	public void error(String msg, Throwable t) {
-		print(error,msg + t.getStackTrace());
+		print(error,msg);
+		printStackTraceRecursive(t);
 	}
 	
 	/**
@@ -132,6 +133,13 @@ public class Logger {
 	
 	private String getThreadName() {
 		return Thread.currentThread().getName();
+	}
+	
+	private void printStackTraceRecursive(Throwable t) {
+		if ((t != null) && ( t.getStackTrace() != null)) {
+			t.printStackTrace();
+			printStackTraceRecursive(t.getCause());
+		}
 	}
 
 	public boolean isDebugEnabled() {


### PR DESCRIPTION
Display complete stacktrace of containing all causes of exception
