### PR TITLE
Cannot find Markers view on Mac

### DIFF
--- a/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/view/View.java
+++ b/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/view/View.java
@@ -208,7 +208,7 @@ public abstract class View extends WorkbenchPart{
 						.getActiveWorkbenchWindow().getActivePage()
 						.getViewReferences();
 				for (IViewReference iViewReference : views) {
-					if (iViewReference.getTitle().equals(title)) {
+					if (iViewReference.getPartName().equals(title)) {
 						return iViewReference.getView(false);
 					}
 				}


### PR DESCRIPTION
A view 'Markers' is sometimes not found on mac. The reason is the condition in View.java:211

if (iViewReference.getTitle().equals(title))

where iViewReference.getTitle() sometimes returns the following

"Markers (0 items)"
