### PR TITLE
BrowserTest.navigate test is failing

### DIFF
--- a/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/browser/BrowserTest.java
+++ b/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/browser/BrowserTest.java
@@ -19,8 +19,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
 public class BrowserTest extends RedDeerTest{
-	private static final String JBOSS_URL = "http://www.jboss.org";
-	private static final String GIT_HUB_URL = "http://www.github.com";
 	private static final String BROWSER_LABEL = "Test browser:";
 	@Override
 	public void setUp() {
@@ -78,13 +76,18 @@ public class BrowserTest extends RedDeerTest{
 	@Test
 	public void navigate(){
 		Browser browser = new InternalBrowser(0);
-		browser.setURL(BrowserTest.JBOSS_URL);
-		assertTrue("Browser has to contain text 'jboss.org' but it doesn't",browser.getText().contains("jboss.org"));
-		browser.setURL(BrowserTest.GIT_HUB_URL);
-		assertTrue("Browser has to contain text 'github.com' but it doesn't",browser.getText().contains("github.com"));
+		browser.setURL("http://www.eclipse.org/swt/snippets/");
+		final String snippetsPageContent = "<title>SWT Snippets</title>";
+		assertTrue("Browser has to contain text '" + snippetsPageContent + "' but it doesn't",
+			browser.getText().contains(snippetsPageContent));
+		browser.setURL("http://www.eclipse.org/swt/widgets/");
+		final String widgetsPageContent = "<title>SWT Widgets</title>";
+		assertTrue("Browser has to contain text '" + widgetsPageContent + "' but it doesn't",
+			browser.getText().contains(widgetsPageContent));
 		browser.back();
-		assertTrue("Browser has to contain text 'jboss.org' but it doesn't",browser.getText().contains("jboss.org"));
+		assertTrue("Browser has to contain text '" + snippetsPageContent + "' but it doesn't",
+				browser.getText().contains(snippetsPageContent));
 		browser.forward();
-		assertTrue("Browser has to contain text 'github.com' but it doesn't",browser.getText().contains("github.com"));
-	}
+		assertTrue("Browser has to contain text '" + widgetsPageContent + "' but it doesn't",
+				browser.getText().contains(widgetsPageContent));	}
 }


### PR DESCRIPTION
BrowserTest.navigate test failing on stable linux (fenix)  http://machydra.brq.redhat.com:8080/view/Reddeer/job/RedDeer_master_matrix/160/jdk=sunjdk1.6,label=stable-linux/testReport/?

Error Message

Browser has to contain text 'jboss.org' but it doesn't
Stacktrace

java.lang.AssertionError: Browser has to contain text 'jboss.org' but it doesn't
    at org.junit.Assert.fail(Assert.java:88)
    at org.junit.Assert.assertTrue(Assert.java:41)
    at org.jboss.reddeer.swt.test.impl.browser.BrowserTest.navigate(BrowserTest.java:82)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:53)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
    at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
    at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:85)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:72)
    at java.lang.Thread.run(Thread.java:662)
