### PR TITLE
All log4j dependencies removed from RedDeer

### DIFF
--- a/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -12,8 +12,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.jface;bundle-version="0.2.0",
  org.jboss.reddeer.swt;bundle-version="0.2.0",
  org.jboss.reddeer.workbench;bundle-version="0.2.0",
- org.apache.log4j;bundle-version="1.2.0",
-  org.hamcrest.core;bundle-version="1.3.0",
+ org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.ui.workbench,
  org.jboss.reddeer.junit;bundle-version="0.4.0"
 Bundle-ActivationPolicy: lazy
@@ -42,5 +41,4 @@ Export-Package: org.jboss.reddeer.eclipse,
  org.jboss.reddeer.eclipse.wst.server.ui,
  org.jboss.reddeer.eclipse.wst.server.ui.view,
  org.jboss.reddeer.eclipse.wst.server.ui.wizard
-Eclipse-RegisterBuddy: org.apache.log4j
 Import-Package: org.junit

--- a/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Activator: org.jboss.reddeer.jface.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.jboss.reddeer.swt;bundle-version="0.2.0",
- org.apache.log4j;bundle-version="1.2.0",
  org.hamcrest.core;bundle-version="1.3.0",
  org.jboss.reddeer.junit;bundle-version="0.4.0"
 Bundle-ActivationPolicy: lazy
@@ -16,4 +15,3 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.eclipse.jface.exception,
  org.jboss.reddeer.eclipse.jface.preference,
  org.jboss.reddeer.eclipse.jface.wizard
-Eclipse-RegisterBuddy: org.apache.log4j

--- a/org.jboss.reddeer.junit.test/pom.xml
+++ b/org.jboss.reddeer.junit.test/pom.xml
@@ -74,11 +74,5 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-			<scope>runtime</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -8,9 +8,7 @@ Bundle-Activator: org.jboss.reddeer.junit.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.junit;bundle-version="4.0.0",
- org.hamcrest.core;bundle-version="1.3.0",
- org.apache.log4j;bundle-version="1.2.0",
- org.apache.commons.logging;bundle-version="1.0.4"
+ org.hamcrest.core;bundle-version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,
@@ -24,4 +22,3 @@ Export-Package: org.jboss.reddeer.junit,
  org.jboss.reddeer.junit.requirement.inject,
  org.jboss.reddeer.junit.runner,
  org.jboss.reddeer.junit.watcher
-Eclipse-RegisterBuddy: org.apache.log4j

--- a/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.junit;bundle-version="0.2.0",
  org.junit;bundle-version="4.10.0",
  org.jboss.reddeer.requirements;bundle-version="0.2.0",
- org.apache.log4j;bundle-version="1.2.15",
  org.jboss.reddeer.eclipse;bundle-version="0.2.0",
  org.jboss.reddeer.jface;bundle-version="0.2.0",
  org.jboss.reddeer.swt.test;bundle-version="0.2.0"

--- a/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.jboss.reddeer.junit;bundle-version="0.2.0",
  org.jboss.reddeer.eclipse;bundle-version="0.2.0",
- org.jboss.reddeer.workbench;bundle-version="0.2.0",
- org.apache.log4j;bundle-version="1.2.15"
+ org.jboss.reddeer.workbench;bundle-version="0.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: JBoss by Red Hat

--- a/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
@@ -1,5 +1,4 @@
 Manifest-Version: 1.0
-Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer SWT Component Tests
 Bundle-Vendor: JBoss by Red Hat
@@ -11,8 +10,7 @@ Require-Bundle: org.eclipse.ui,
  org.junit;bundle-version="4.11.0",
  org.jboss.reddeer.swt;bundle-version="0.2.0",
  org.jboss.reddeer.workbench;bundle-version="0.2.0",
- org.hamcrest.core;bundle-version="1.3.0",
- org.apache.log4j;bundle-version="1.2.12",
+ org.hamcrest.core;bundle-version="1.3.0", 
  org.eclipse.core.expressions,
  org.eclipse.ui.views.log,
  org.eclipse.m2e.core.ui,

--- a/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
@@ -1,5 +1,4 @@
 Manifest-Version: 1.0
-Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer SWT Component
 Bundle-Vendor: JBoss by Red Hat
@@ -11,7 +10,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.forms,
  org.eclipse.core.runtime,
  org.hamcrest.core;bundle-version="1.3.0",
- org.apache.log4j;bundle-version="1.2.13",
  org.eclipse.swt,
  org.jboss.reddeer.junit;bundle-version="0.4.0"
 Bundle-ActivationPolicy: lazy

--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/condition/ShellWithTextIsAvailable.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/condition/ShellWithTextIsAvailable.java
@@ -1,6 +1,6 @@
 package org.jboss.reddeer.swt.condition;
 
-import org.apache.log4j.Logger;
+import org.jboss.reddeer.junit.logging.Logger;
 import org.eclipse.swt.widgets.Shell;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.IsEqual;

--- a/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/WaitUntil.java
+++ b/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/WaitUntil.java
@@ -1,6 +1,6 @@
 package org.jboss.reddeer.swt.wait;
 
-import org.apache.log4j.Logger;
+import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.condition.WaitCondition;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException;

--- a/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
@@ -1,5 +1,4 @@
 Manifest-Version: 1.0
-Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer UI Component
 Bundle-SymbolicName: org.jboss.reddeer.ui;singleton:=true
@@ -19,6 +18,5 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.pde.ui,
  org.jboss.reddeer.jface;bundle-version="0.2.0",
  org.jboss.reddeer.swt;bundle-version="0.2.0",
- org.jboss.reddeer.workbench;bundle-version="0.2.0",
- org.apache.log4j;bundle-version="1.2.0"
+ org.jboss.reddeer.workbench;bundle-version="0.2.0"
 

--- a/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
@@ -12,8 +12,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.workbench,
  org.jboss.reddeer.uiforms,
  org.hamcrest.core;bundle-version="1.3.0",
- org.junit,
- org.apache.log4j;bundle-version="1.2.13"
+ org.junit
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.uiforms.test

--- a/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.forms,
  org.jboss.reddeer.swt,
  org.hamcrest.core;bundle-version="1.3.0",
- org.apache.log4j;bundle-version="1.2.13",
  org.eclipse.ui.forms
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
+++ b/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.jboss.reddeer.swt;bundle-version="0.2.0",
  org.hamcrest.core;bundle-version="1.3.0",
- org.apache.log4j;bundle-version="1.2.13",
  org.eclipse.jface.text;bundle-version="3.8.100",
  org.jboss.reddeer.junit;bundle-version="0.4.0",
  org.eclipse.ui.editors;bundle-version="3.8.100"


### PR DESCRIPTION
Replace remaining log4j loggers with simple RedDeer console logger and remove all log4j references
