### PR TITLE
Changed method operateServerState(menuItem, resultState) #339

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/Server.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/Server.java
@@ -160,10 +160,12 @@ public class Server {
 	protected void operateServerState(String menuItem, ServerState resultState){
 		select();
 		new ContextMenu(menuItem).select();
-		AbstractWait.sleep(TimePeriod.SHORT.getSeconds() * 1000);
-		final TimePeriod DOUBLED_TIMEOUT = TimePeriod.getCustom(TIMEOUT.getSeconds() * 2);
-		new WaitUntil(new ServerStateCondition(resultState), DOUBLED_TIMEOUT);
+		new WaitUntil(new JobIsRunning(), TIMEOUT);
+		new WaitUntil(new ServerStateCondition(resultState), TIMEOUT);
 		new WaitWhile(new JobIsRunning(), TIMEOUT);
+		
+		//check if the server has expected state after jobs are done
+		new WaitUntil(new ServerStateCondition(resultState), TIMEOUT);
 	}
 	
 	protected void waitForPublish(){


### PR DESCRIPTION
The method first wait until any job is running and then check the server's state. However, new servers stops too fast so all jobs are done before the waiting, so it is waiting until TIME OUT.

I removed waiting for jobs and doubled time out of server's state checking to preserve time in which server should stop.
