### PR TITLE
Bad implementation of WidgetHandler.setFocus

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/WidgetHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/WidgetHandler.java
@@ -736,18 +736,18 @@ public class WidgetHandler {
 		Display.syncExec(new Runnable() {
 			@Override
 			public void run() {
-				if (w instanceof Control) {
-					((Control)w).setFocus();
-				} else if (w instanceof ExpandBar){
+				if (w instanceof ExpandBar){
 					((ExpandBar)w).setFocus();
 				} else if (w instanceof Browser){
 					((Browser)w).setFocus();
 				} else if (w instanceof Scale){
 					((Scale)w).setFocus();
 				} else if(w instanceof Shell) {
-					Shell shell =(Shell) w; 
+					Shell shell = (Shell) w; 
 					shell.forceActive();
 					shell.forceFocus();
+				} else if (w instanceof Control) {
+					((Control)w).setFocus();
 				} else throw new SWTLayerException("Unsupported type");
 			}
 		});


### PR DESCRIPTION
Look at the first condition which is

if (w instanceof Control) {
  ((Control)w).setFocus();
} else if ...                

this condition is almost always satisfied since lots of widgets extend this class. For exmaple, that's why the shell activation is not working, the code is never called
