### PR TITLE
Import projects dialog always import all projects

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/AbstractButton.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/AbstractButton.java
@@ -36,6 +36,7 @@ public abstract class AbstractButton implements Button {
 				swtButton = ButtonLookup.getInstance().getButton(refComposite,
 						index, new StyleMatcher(style));
 			}
+			WidgetHandler.getInstance().setFocus(swtButton);
 	}
 	@Override
 	public void click() {


### PR DESCRIPTION
Try this code

``` java
        ExternalProjectImportWizardDialog w = new ExternalProjectImportWizardDialog();
        w.open();
        WizardProjectsImportPage p1 = w.getFirstPage();
        p1.setRootDirectory(dir);
        p1.deselectAllProjects();
        p1.selectProjects("p1");
        p1.copyProjectsIntoWorkspace(true);
        w.finish();
```

all project are imported but only p1 should be
