### PR TITLE
Allows BrowserView to use already existing InternalBrowser instance

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserView.java
@@ -32,15 +32,22 @@ public class BrowserView extends WorkbenchView {
 		super("Internal Web Browser");
 	}
 
+	public BrowserView(InternalBrowser browser) {
+		this();
+
+		this.browser = browser;
+	}
+
 	/**
 	 * Opens Internal Web Browser view
 	 */
 	@Override
 	public void open() {
-		if(!isOpen()){
+		if(!isOpen())
 			super.open();
-		}
-		browser = new InternalBrowser();
+
+		if (browser == null)
+			browser = new InternalBrowser();
 	};
 
 	/**
@@ -103,6 +110,12 @@ public class BrowserView extends WorkbenchView {
 	 * Checks if browser is already open
 	 */
 	public boolean isOpen() {
+		/* if InternalBrowser instance exists already, lets assume browser is opened
+		 * - either browser was set in BrowserView(InternalBrowser) constructor and therefore
+		 * it's opened (caller's responsibility) or it was set in open() */
+		if (browser != null)
+			return true;
+
 		try{
 			new InternalBrowser(); 
 			return true;  // browser is already opened

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/browser/BrowserViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/browser/BrowserViewTest.java
@@ -12,11 +12,10 @@ import org.junit.Test;
 
 @Ignore	// https://github.com/jboss-reddeer/reddeer/issues/219
 public class BrowserViewTest extends RedDeerTest{
+	protected static BrowserView browserView;
 
-	private static BrowserView browserView;
-	
-	private static final String FIRST_PAGE = "http://www.redhat.com/";
-	private static final String SECOND_PAGE = "http://www.redhat.com/contact/";
+	protected static final String FIRST_PAGE = "http://www.redhat.com/";
+	protected static final String SECOND_PAGE = "http://www.redhat.com/contact/";
 	
 	@Before
 	public void openBrowser(){

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/browser/BrowserViewWithInternalTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/browser/BrowserViewWithInternalTest.java
@@ -1,0 +1,22 @@
+package org.jboss.reddeer.eclipse.test.ui.browser;
+
+import org.jboss.reddeer.eclipse.ui.browser.BrowserView;
+import org.jboss.reddeer.swt.impl.browser.InternalBrowser;
+import org.junit.Before;
+import org.junit.Ignore;
+
+@Ignore	// https://github.com/jboss-reddeer/reddeer/issues/219
+public class BrowserViewWithInternalTest extends BrowserViewTest {
+	@Before
+	@Override
+	public void openBrowser() {
+		/* Open standard browser - InternalBrowser needs existing widget,
+		 * and this one is just fine. */
+		BrowserView unusedOne = new BrowserView();
+		unusedOne.open();
+
+		/* Create BrowserView using already existing InternalBrowser
+		 * - any other instance could be used */
+		BrowserViewTest.browserView = new BrowserView(new InternalBrowser());
+	}
+}


### PR DESCRIPTION
Test added - I used BrowserViewTest as a parent class - and despite this particular test is marked as ignored, both (BrowserView and BrowserView with passed InternalBrowser) do pass on my machine.
