### PR TITLE
rawagner_Allows user to create DefaultTreeItem using java.util.regex.Pattern

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/DefaultTreeItem.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/DefaultTreeItem.java
@@ -3,15 +3,15 @@ package org.jboss.reddeer.swt.impl.tree;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import org.hamcrest.Matcher;
 import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.api.Tree;
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.condition.TreeItemHasMinChildren;
 import org.jboss.reddeer.swt.condition.WaitCondition;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.matcher.TextMatcher;
 import org.jboss.reddeer.swt.reference.ReferencedComposite;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
@@ -51,11 +51,11 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 	}
 
 	/**
-	 * Tree item with specified path will be constructed, using regular expressions to match each path item
+	 * Tree item with specified path will be constructed
 	 *
 	 * @param treeItemPath
 	 */
-	public DefaultTreeItem(Pattern... treeItemPath) {
+	public DefaultTreeItem(Matcher<String>... treeItemPath) {
 		this((ReferencedComposite)null, 0, treeItemPath);
 	}
 
@@ -69,11 +69,11 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 	}
 
 	/**
-	 * Tree item with specified path inside given composite will be constructed, using regular expressions to match each path item
+	 * Tree item with specified path inside given composite will be constructed
 	 * @param referencedComposite
 	 * @param treeItemPath
 	 */
-	public DefaultTreeItem(ReferencedComposite referencedComposite, Pattern... treeItemPath) {
+	public DefaultTreeItem(ReferencedComposite referencedComposite, Matcher<String>... treeItemPath) {
 		this(referencedComposite, 0, treeItemPath);
 	}
 	
@@ -88,12 +88,12 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 	}
 
 	/**
-	 * Tree item with specified tree index and path will be constructed, using regular expressions to match each path item
+	 * Tree item with specified tree index and path will be constructed
 	 *
 	 * @param treeIndex
 	 * @param treeItemPath
 	 */
-	public DefaultTreeItem(int treeIndex, Pattern... treeItemPath) {
+	public DefaultTreeItem(int treeIndex, Matcher<String>... treeItemPath) {
 		super(findTreeItem((ReferencedComposite)null, treeIndex, treeItemPath));
 	}
 	
@@ -108,12 +108,12 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 	}
 
 	/**
-	 * Tree item with specified tree index and path inside given composite will be constructed, using regular expressions to match each path item
+	 * Tree item with specified tree index and path inside given composite will be constructed
 	 * @param referencedComposite
 	 * @param treeIndex
 	 * @param treeItemPath
 	 */
-	public DefaultTreeItem(ReferencedComposite referencedComposite, int treeIndex, Pattern... treeItemPath) {
+	public DefaultTreeItem(ReferencedComposite referencedComposite, int treeIndex, Matcher<String>... treeItemPath) {
 		super(findTreeItem(referencedComposite, treeIndex, treeItemPath));
 	}
 
@@ -156,7 +156,6 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 	}
 
 	/**
-	 * Tree item with specified tree index and path inside given composite will be constructed
 	 * Tree item with specified tree and path inside this tree will be constructed. Text from
 	 * specified cell will be used instead of item's text.
 	 *
@@ -170,14 +169,13 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 
 	/**
 	 * Tree item with specified tree and path inside this tree will be constructed. Text from
-	 * specified cell will be used instead of item's text. Regular expressions are used to match
-	 * each path item.
+	 * specified cell will be used instead of item's text.
 	 *
 	 * @param tree
 	 * @param cellIndex
 	 * @param treeItemPath
 	 */
-	public DefaultTreeItem(Tree tree, int cellIndex, Pattern... treeItemPath) {
+	public DefaultTreeItem(Tree tree, int cellIndex, Matcher<String>... treeItemPath) {
 		super(findTreeItem(tree, cellIndex, treeItemPath));
 	}
 
@@ -188,12 +186,12 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 		return swtTreeItem;
 	}
 
-	private static SWTLayerException createItemNotFoundException(List<TreeItem> items, int cellIndex, Pattern pathItem, Pattern[] treeItemPath, Integer treeItemIndex) {
+	private static SWTLayerException createItemNotFoundException(List<TreeItem> items, int cellIndex, Matcher<String> pathItem, Matcher<String>[] treeItemPath, Integer treeItemIndex) {
 		SWTLayerException exception = new SWTLayerException("No matching tree item found");
 
 		if (treeItemPath != null) {
 			StringBuffer sbPath = new StringBuffer("");
-			for (Pattern treeItem : treeItemPath) {
+			for (Matcher<String> treeItem : treeItemPath) {
 				if (sbPath.length() > 0)
 					sbPath.append(" > ");
 				sbPath.append(treeItem.toString());
@@ -225,7 +223,7 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 	 * @param treeItemPath
 	 * @return
 	 */
-	private static org.eclipse.swt.widgets.TreeItem findTreeItem(Tree tree, int cellIndex, Pattern... treeItemPath) {
+	private static org.eclipse.swt.widgets.TreeItem findTreeItem(Tree tree, int cellIndex, Matcher<String>... treeItemPath) {
 		logger.debug(String.format("Search for tree item: cellIndex=%d, treeItemPath='%s'", cellIndex, treeItemPath.toString()));
 
 		/*
@@ -235,17 +233,17 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 		 * the next iteration. Throw exception otherwise, also throw one
 		 * if we run out of treeItemPath entries without matching any item.
 		 *
-		 * Each entry is matched using regex pattern. If constructor was
-		 * called to create DefaultTreeItem using String array as treeItemPath,
-		 * it's responsibility of caller of this method to convert each item
-		 * from String to Pattern (most probably using Pattern.quote())
+		 * If constructor was called to create DefaultTreeItem using String
+		 * array as treeItemPath, it's responsibility of caller of this method
+		 * to convert each item from String to Matcher<String> (most probably
+		 * using TextMatcher)
 		 */
 
 		new WaitUntil(new TreeHasChildren(tree));
 		List<TreeItem> items = tree.getItems();
 
 		for(int index = 0; index < treeItemPath.length; index++) {
-			Pattern pathItem = treeItemPath[index];
+			Matcher<String> pathItem = treeItemPath[index];
 
 			logger.debug(String.format("  pathItem='%s'", pathItem.toString()));
 
@@ -257,8 +255,7 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 				tiItem = itTreeItem.next();
 				logger.debug(String.format("    consider item '%s'", tiItem.getCell(cellIndex)));
 
-				Matcher m = pathItem.matcher(tiItem.getCell(cellIndex));
-				if (m.matches()) {
+				if (pathItem.matches(tiItem.getCell(cellIndex))) {
 					logger.debug("      item matched!");
 
 					isFound = true;
@@ -287,7 +284,7 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 	}
 
 	/**
-	 * Find tree item by its path. Item path is converted to array of Pattern objects by quoting each item,
+	 * Find tree item by its path. Item path is converted to array of TextMatcher,
 	 * so its literal is used for matching.
 	 *
 	 * @param tree Tree to search for item
@@ -296,12 +293,12 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 	 * @return
 	 */
 	private static org.eclipse.swt.widgets.TreeItem findTreeItem(Tree tree, int cellIndex, String... treeItemPath) {
-		Pattern treeItemPathPatterns[] = new Pattern[treeItemPath.length];
+		TextMatcher treeItemPathMatchers[] = new TextMatcher[treeItemPath.length];
 
 		for(int i = 0; i < treeItemPath.length; i++)
-			treeItemPathPatterns[i] = Pattern.compile(Pattern.quote(treeItemPath[i]));
+			treeItemPathMatchers[i] = new TextMatcher(treeItemPath[i]);
 
-		return findTreeItem(tree, cellIndex, treeItemPathPatterns);
+		return findTreeItem(tree, cellIndex, treeItemPathMatchers);
 	}
 
 	/**
@@ -331,7 +328,7 @@ protected static final Logger logger = Logger.getLogger(DefaultTreeItem.class);
 		return findTreeItem(new DefaultTree(referencedComposite, treeIndex), 0, treeItemPath);
 	}
 
-	private static org.eclipse.swt.widgets.TreeItem findTreeItem(ReferencedComposite referencedComposite, int treeIndex, Pattern... treeItemPath) {
+	private static org.eclipse.swt.widgets.TreeItem findTreeItem(ReferencedComposite referencedComposite, int treeIndex, Matcher<String>... treeItemPath) {
 		return findTreeItem(new DefaultTree(referencedComposite, treeIndex), 0, treeItemPath);
 	}
 }

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/tree/AbstractTreeTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/tree/AbstractTreeTest.java
@@ -1,6 +1,7 @@
 package org.jboss.reddeer.swt.test.impl.tree;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -23,6 +24,7 @@ import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
 import org.jboss.reddeer.swt.test.RedDeerTest;
 import org.jboss.reddeer.swt.test.ui.views.TreeEventsListener;
 import org.jboss.reddeer.swt.util.Display;
@@ -294,7 +296,25 @@ public class AbstractTreeTest extends RedDeerTest {
     assertTrue("Cell [1] of tree item has to be empty but is" + cellLabel,
       cellLabel.length() == 0);
   }
-  
+
+	@Test
+	public void testFindUsingRegexMatcher() {
+		createTreeItems(tree.getSWTWidget());
+
+		String expected;
+		DefaultTreeItem dfi;
+
+		expected = "AA";
+		dfi = new DefaultTreeItem(new RegexMatcher("A"), new RegexMatcher("A+"));
+		assertEquals(String.format("Found item with text '%s', '%s' expected", dfi.getText(), expected),
+				expected, dfi.getText());
+
+		expected = "AAB";
+		dfi = new DefaultTreeItem(new RegexMatcher("A"), new RegexMatcher("A+"), new RegexMatcher("A+B"));
+		assertEquals(String.format("Found item with text '%s', '%s' expected", dfi.getText(), expected),
+				expected, dfi.getText());
+	}
+
   private void removeTreeItems (final Tree tree){
     Display.syncExec(new Runnable() {
       @Override


### PR DESCRIPTION
... for path matching instead of strings.

Tests pass for me locally.

This feature is useful for dealing with trees where item's text contain substring that is not (easily) predictable (e.g. project members of (git/svn/cvs)-backed project contain also revision number). Extends API and changes internals a bit - regex matching is now default (Matcher.matches instead of String.equals), Strings are converted by Pattern.quote to proper patterns.
