### PR TITLE
Undo changes for javadoc - not needed (#46)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,14 +147,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
-				<configuration>
-					<aggregate>true</aggregate>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
It turns out the plugin config in pom.xml is not needed.
