### PR TITLE
Increased timeout for Eclipse tests. Fixed default settings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<logDebug>true</logDebug>
 		<pauseFailedTest>false</pauseFailedTest>
 		<recordScreenCast>false</recordScreenCast>
+		<surefire.timeout>2400</surefire.timeout>
 	</properties>
 	
 	<modules>
@@ -93,8 +94,6 @@
 				<version>${tycho-version}</version>
 		
 				<configuration>
-					<surefire.timeout>2400</surefire.timeout>
-					<forkedProcessTimeoutInSeconds>2400</forkedProcessTimeoutInSeconds>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
 					<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->

--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -12,6 +12,10 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 
+	<properties>
+		<surefire.timeout>3000</surefire.timeout>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>hsqldb</groupId>


### PR DESCRIPTION
Our root pom's tycho-surefire-plugin contained unnecessary timeout
configuration. It's better to rely on sure.timeout and the tycho surefire
plugin inherits that. Eclipse tests have custom timeout of 3000 sec - the
default 2400 was not enough on Mac (and Windows was getting close).
