### PR TITLE
Use consideredJobs/ignoredJobs matchers to allow user to filter jobs in a more flexible way

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/condition/JobIsRunning.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/condition/JobIsRunning.java
@@ -1,40 +1,85 @@
 package org.jboss.reddeer.swt.condition;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.core.runtime.jobs.Job;
+import org.hamcrest.Matcher;
+import org.hamcrest.CoreMatchers;
+import org.jboss.reddeer.junit.logging.Logger;
 
 /**
  * Returns true, if there is a non system job running, false 
- * otherwise. 
+ * otherwise. List of tested jobs can be altered using matchers
+ * with proper constructor.
  * 
  * @author Lucia Jelinkova
- *
  */
+@SuppressWarnings("rawtypes")
 public class JobIsRunning implements WaitCondition {
+	private Logger log = Logger.getLogger(JobIsRunning.class);
 
+	private Matcher[] consideredJobs;
+	private Matcher[] excludeJobs;
+
+	public JobIsRunning() {
+		this(null, null);
+	}
+
+	/**
+	 * @param consideredJobs If not <code>null</code>, only jobs whose name matches
+	 * any of these matchers will be tested. Use in case you want to make sure all
+	 * jobs from a limited set are not running, and you don't care about the rest
+	 * of jobs.
+	 */
+	public JobIsRunning(Matcher[] consideredJobs) {
+		this(consideredJobs, null);
+	}
+
+	/**
+	 * @param consideredJobs If not <code>null</code>, only jobs whose name matches
+	 * any of these matchers will be tested. Use in case you want to make sure all
+	 * jobs from a limited set are not running, and you don't care about the rest
+	 * of jobs.
+	 * @param excludeJobs If not <code>null</code>, jobs whose name matches any of
+	 * these matcher will be ignored. Use in case you don't care about limited set
+	 * of jobs. These matchers will overrule <code>consideredJobs</code> results,
+	 * job matched by both <code>consideredJobs</code> and <code>excludeJobs</code>
+	 * will be excluded.
+	 */
+	public JobIsRunning(Matcher[] consideredJobs, Matcher[] excludeJobs) {
+		this.consideredJobs = consideredJobs;
+		this.excludeJobs = excludeJobs;
+	}
+
+	@SuppressWarnings("unchecked")
 	@Override
 	public boolean test() {
-		return getJobs().size() != 0;
+		log.debug("test:");
+
+		for (Job job: Job.getJobManager().find(null)) {
+			if (excludeJobs != null && CoreMatchers.anyOf(excludeJobs).matches(job.getName())) {
+				log.debug("  job '%s' specified by excludeJobs matchers, skipped", job.getName());
+				continue;
+			}
+
+			if (consideredJobs != null && !CoreMatchers.anyOf(consideredJobs).matches(job.getName())) {
+				log.debug("  job '%s' is not listed in considered jobs, ignore it", job.getName());
+				continue;
+			}
+
+			if (job.isSystem() || job.getState() == Job.SLEEPING) {
+				log.debug("  job '%s' is system job or not running, skipped", job.getName());
+				continue;
+			}
+
+			/* there's no reason why this one should be ignored, lets wait... */
+			log.debug("  job '%s' has no excuses, wait for it", job.getName());
+			return true;
+		}
+
+		return false;
 	}
-	
+
 	@Override
 	public String description() {
-		StringBuilder msg = new StringBuilder("At least one job is running. Currently running jobs: \n");
-		for (Job job : getJobs()){
-			msg.append(job.getName() + "\n");
-		}
-		return msg.toString();
-	}
-	
-	private List<Job> getJobs(){
-		List<Job> jobs = new ArrayList<Job>();
-		for (Job job : Job.getJobManager().find(null)){
-			if (!job.isSystem() && Job.SLEEPING != job.getState()){
-				jobs.add(job);
-			}
-		}
-		return jobs;
+		return "At least one job is running.";
 	}
 }


### PR DESCRIPTION
My previous patch, modified according to notes from Vlado Pakan. User can specify two arrays of matchers - only jobs that pass consideredJobs matchers will be checked (effectively ignoring fact there may be other running jobs), and jobs that pass excludeJobs matchers will be ignored (ignore running jobs user does not care about).

Unfortunately, I removed previous branch while squashing and rebasing commits into one, therefore new pull request (and lost history...), sorry for that.
