### PR TITLE
Changed test method's name to unique name for each run/config #420

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunner.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunner.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.jboss.reddeer.junit.logging.Logger;
+import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
 import org.jboss.reddeer.junit.internal.requirement.Requirements;
 import org.jboss.reddeer.junit.internal.requirement.inject.RequirementsInjector;
 import org.jboss.reddeer.junit.internal.screenrecorder.ScreenRecorderExt;
@@ -14,6 +15,7 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
 
@@ -34,11 +36,14 @@ public class RequirementsRunner extends BlockJUnit4ClassRunner {
 
 	private RequirementsInjector requirementsInjector = new RequirementsInjector();
 	
+	private String configId;
+
 	private static boolean SAVE_SCREENCAST = System.getProperty("recordScreenCast","false").equalsIgnoreCase("true");
 	
-	public RequirementsRunner(Class<?> clazz, Requirements requirements) throws InitializationError {
+	public RequirementsRunner(Class<?> clazz, Requirements requirements, String configId) throws InitializationError {
 		super(clazz);
 		this.requirements = requirements;
+		this.configId = configId;
 	}
 
 	@Override
@@ -54,7 +59,12 @@ public class RequirementsRunner extends BlockJUnit4ClassRunner {
 		requirementsInjector.inject(testInstance, requirements);
 		return testInstance;
 	}
-
+	
+	@Override
+	protected String testName(FrameworkMethod method) {
+		return method.getName()+" "+configId;
+	}
+	
 	@Override
 	public void run(RunNotifier arg0) {
 		LoggingRunListener loggingRunListener = new LoggingRunListener();

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
@@ -32,7 +32,7 @@ public class RequirementsRunnerBuilder extends RunnerBuilder {
 		Requirements requirements = requirementsBuilder.build(clazz, config.getRequirementConfiguration());
 		if (requirements.canFulfill()){
 			log.info("All requirements can be fulfilled, the test will run");
-			return new RequirementsRunner(clazz, requirements);
+			return new RequirementsRunner(clazz, requirements, config.getId());
 		} else {
 			log.info("All requirements cannot be fulfilled, the test will NOT run");
 			return null;

--- a/tests/org.jboss.reddeer.junit.test/src/test/java/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/test/java/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerTest.java
@@ -16,7 +16,7 @@ public class RequirementsRunnerTest {
 	public void testInjectMethodInvocation() throws Exception {
 		
 		Requirements requirements = mock(Requirements.class);
-		requirementsRunner = new RequirementsRunner(SimpleTest.class, requirements);
+		requirementsRunner = new RequirementsRunner(SimpleTest.class, requirements, "no config");
 		
 		RequirementsInjector reqInjector = mock(RequirementsInjector.class);
 		requirementsRunner.setRequirementsInjector(reqInjector);


### PR DESCRIPTION
This PR solves broken Tree in Eclipse's JUnit View.

The problem is solved by creating unique method's name for each run/config, which is done by joining method's name with config's name.

The idea is based on the fact that if there are more methods with the same name then only the last one shows result in JUnit View's tree and the others are empty.
