### PR TITLE
ProjectItem.getChild(String) doesn't create valid object

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/ProjectItem.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/ProjectItem.java
@@ -66,7 +66,7 @@ public class ProjectItem {
 		String[] childPath = new String[path.length + 1];
 		System.arraycopy(path, 0, childPath, 0, path.length);
 		childPath[childPath.length - 1] = text;
-		return new ProjectItem(treeItem.getItem(text), project, path);
+		return new ProjectItem(treeItem.getItem(text), project, childPath);
 	}
 	
 	public String getText() {

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/packageexplorer/ProjectItemTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/packageexplorer/ProjectItemTest.java
@@ -88,6 +88,10 @@ public class ProjectItemTest extends RedDeerTest {
 		assertTrue("Found Project Item has to have text " + ProjectItemTest.DEFAULT_PACKAGE_TEXT
 				  + " but is " + piDefaultPackage.getText(),
 				piDefaultPackage.getText().equals(ProjectItemTest.DEFAULT_PACKAGE_TEXT));
+		
+		/* select default package */
+		piDefaultPackage.select();
+		assertTrue("Project item " + ProjectItemTest.DEFAULT_PACKAGE_TEXT + " is not selected" , piDefaultPackage.isSelected());
 	}
 	
 	@Test


### PR DESCRIPTION
Method getChild(String) creates ProjectItem with wrong path.

For example, when you call method getChild("(default package)") on ProjectItem with path "ProjectTest/src" then the created ProjectItem has path "ProjectTest/src" instead of "ProjectItem/src/(default package)".

Also you can test this bug by calling method select() of created object and you'll see that the parent is selected instead of selecting created child.
