### PR TITLE
LabelMatcher using Matcher

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/LabelMatcher.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/LabelMatcher.java
@@ -7,41 +7,52 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.Is;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 
 /**
  * Label matcher
- * @author Rastislav Wagner
+ * @author Rastislav Wagner, Radoslav Rabara
  * 
  */
 public class LabelMatcher extends BaseMatcher<String> {
 
-	private String label;
+	private Matcher<String> matcher;
 	
 	/**
 	 * Creates label matcher
 	 * @param label given label for matcher usage
 	 */
 	public LabelMatcher(String label) {
-		this.label = label;
+		this(Is.<String>is(label));
+	}
+	
+	/**
+	 * Creates label matcher from string matcher
+	 * @param matcher given matcher used to match label
+	 */
+	public LabelMatcher(Matcher<String> matcher) {
+		if(matcher == null)
+			throw new NullPointerException("matcher");
+		this.matcher = matcher;
 	}
 	
 	@Override
 	public void describeTo(Description description) {
-		// TODO Auto-generated method stub
-
+		description.appendText("label ").appendDescriptionOf(matcher);
 	}
 
 	/**
 	 * Matches given object
-	 * @returns true if object is matching given label
+	 * @returns true if object's label is matching
 	 */
 	@Override
 	public boolean matches(Object item) {
 		
 		if ((item instanceof List) || (item instanceof Text) || (item instanceof Combo) || (item instanceof Spinner)) {
 			String widgetLabel = WidgetHandler.getInstance().getLabel((Widget)item);
-			if (widgetLabel != null && widgetLabel.equals(label)) {
+			if (widgetLabel != null && matcher.matches(widgetLabel)) {
 				return true;
 			}
 		}
@@ -50,7 +61,7 @@ public class LabelMatcher extends BaseMatcher<String> {
 	
 	@Override
 	public String toString() {
-		return "Matcher matching label \"" + label +"\"";
+		return "Matcher matching label:\n" + matcher.toString();
 	}
 	
 }


### PR DESCRIPTION
Sometimes we need more than just exact string match to find widget with label (e.g. using StringContains or AnyOf).

Because of that, LabelMatcher should be able to use Matcher in order to find Text/Combo/List/Spinner with label that matches to given matcher.
