### PR TITLE
Just correction of misleading javadoc.

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/util/Utils.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/util/Utils.java
@@ -5,7 +5,7 @@ import org.eclipse.core.runtime.Platform;
 /**
  * Provides common utils
  * @author Vlado Pakan
- * @deprecated use ExecutionContext for OS related methods and 
+ * @deprecated use RunningPlatform from org.jboss.reddeer.direct plugin for OS related methods and 
  *
  */
 public class Utils {


### PR DESCRIPTION
In deprecated section was mentioned ExecutionContext. I don't think such thing exists in RedDeer and I'm supposing it is just a mistake and RunningPlatform should have been mentioned.
