### PR TITLE
Implement getWizardPage(int pageIndex)

### DIFF
--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardDialog.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardDialog.java
@@ -54,11 +54,29 @@ public class WizardDialog {
 	public WizardPage getFirstPage() {
 		return getWizardPage();
 	}
+	
+	/**
+	  * Returns a current wizard page
+	 * 
+	 * @return current wizard page
+	 */
 
+	public WizardPage getCurrentWizardPage() {
+		for (WizardPage wizardPage : wizardPageMap.keySet()) {
+			Matcher<WizardDialog> matcher = wizardPageMap.get(wizardPage);
+			if (matcher.matches(this)) {
+				return wizardPage;
+			}
+		}
+		log.warn("No wizard page found in page index '" + currentPage + "'");
+		return null;
+	}
+	
 	/**
 	 * Returns a current wizard page
 	 * 
 	 * @return current wizard page
+	 * @deprecated use getCurrentWizardPage() instead
 	 */
 	public WizardPage getWizardPage() {
 		for (WizardPage wizardPage : wizardPageMap.keySet()) {
@@ -69,6 +87,18 @@ public class WizardDialog {
 		}
 		log.warn("No wizard page found in page index '" + currentPage + "'");
 		return null;
+	}
+	
+	/**
+	 * Automatically lists to desired wizard page and returns it.
+	 * 
+	 * @param page index of desired wizard page
+	 * @return instance of desired WizardPage
+	 */
+	
+	public WizardPage getWizardPage(int pageIndex){
+		selectPage(pageIndex);
+		return getCurrentWizardPage();
 	}
 
 	/**

--- a/tests/org.jboss.reddeer.jface.test/src/org/jboss/reddeer/jface/test/wizard/WizardDialogTest.java
+++ b/tests/org.jboss.reddeer.jface.test/src/org/jboss/reddeer/jface/test/wizard/WizardDialogTest.java
@@ -1,8 +1,9 @@
 package org.jboss.reddeer.jface.test.wizard;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.Is.is;
 
 import org.jboss.reddeer.eclipse.jface.exception.JFaceLayerException;
 import org.jboss.reddeer.eclipse.jface.wizard.WizardDialog;
@@ -101,10 +102,10 @@ public class WizardDialogTest extends RedDeerTest {
 	@Test
 	public void multiPageWizardTest() {
 		// fill name
-		wizardDialog.getWizardPage().fillWizardPage("name");
+		wizardDialog.getCurrentWizardPage().fillWizardPage("name");
 		// on next page you should see a text box for age 
 		wizardDialog.next();
-		wizardDialog.getWizardPage().fillWizardPage("100");
+		wizardDialog.getCurrentWizardPage().fillWizardPage("100");
 	}
 	
 	@Test
@@ -112,7 +113,18 @@ public class WizardDialogTest extends RedDeerTest {
 		// don't fill name
 		// on next page you should see a text box for name again
 		wizardDialog.next();
-		wizardDialog.getWizardPage().fillWizardPage("name");
+		wizardDialog.getCurrentWizardPage().fillWizardPage("name");
+	}
+	
+	@Test
+	public void getWizardPageTest(){
+		WizardPage page = wizardDialog.getWizardPage(1);
+		assertThat(page, instanceOf(NameWizardPage.class));
+		page.fillWizardPage("name");
+		page = wizardDialog.getWizardPage(0);
+		assertThat(page, instanceOf(NameWizardPage.class));
+		page = wizardDialog.getWizardPage(1);
+		assertThat(page, instanceOf(AgeWizardPage.class));
 	}
 
 	@Override


### PR DESCRIPTION
Now, when user wants to go to specific page, he must to list to the page by himself like:

```
selectPage(index);
WizardPage page = getWizardPage();
```

I've implemented simple method `WizardPage getWizardPage(int pageIndex)` to do just that. I believe this will simplify and improve readability of users code.
As part of this PR, I'm  also marking original getWizardPage() as deprecated and replacing it  by getCurrentWizardPage() from the same reason (name getWizardPage is not so clear as getCurrentWizardPage)
