### PR TITLE
Text.setText in current implementation is not sufficient

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/api/Text.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/api/Text.java
@@ -33,5 +33,12 @@ public interface Text extends Widget{
 	 */
 	void setFocus();
 	
+	/**
+	 * Types text using @link(org.jboss.reddeer.swt.keyboard.Keyboard)
+	 * @param text
+	 */
+	
+	void typeText(String text);
+	
 	org.eclipse.swt.widgets.Text getSWTWidget();
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/text/AbstractText.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/text/AbstractText.java
@@ -3,6 +3,7 @@ package org.jboss.reddeer.swt.impl.text;
 import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.api.Text;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
+import org.jboss.reddeer.swt.keyboard.KeyboardFactory;
 import org.jboss.reddeer.swt.lookup.WidgetLookup;
 
 /**
@@ -50,4 +51,11 @@ public abstract class AbstractText implements Text {
 		return WidgetLookup.getInstance().isEnabled(w);
 	}
 	
+	@Override
+	public void typeText(String text) {
+		setText("");
+		setFocus();
+		KeyboardFactory.getKeyboard().type(text);
+		
+	}
 }

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/LabeledTextTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/LabeledTextTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
@@ -22,6 +24,9 @@ import org.junit.Test;
 
 public class LabeledTextTest extends RedDeerTest{
 	
+	
+	private int modifiedCount = 0;
+	
 	@Override
 	public void setUp() {
 		super.setUp();
@@ -36,6 +41,7 @@ public class LabeledTextTest extends RedDeerTest{
 				shell.setFocus();
 			}
 		});
+		modifiedCount = 0;
 	}
 	
 	private void createControls(Shell shell){
@@ -82,6 +88,13 @@ public class LabeledTextTest extends RedDeerTest{
 		swtText1.setText("Test text1");
 		swtText1.setSize(100,30);
 		swtText1.setLocation(250,150);
+		swtText1.addModifyListener(new ModifyListener() {
+			
+			@Override
+			public void modifyText(ModifyEvent arg0) {
+				modifiedCount++;
+			}
+		});
 		
 		Label swtLabel2= new Label(shell, SWT.BORDER);
 		swtLabel2.setText("Test label2");
@@ -154,6 +167,15 @@ public class LabeledTextTest extends RedDeerTest{
 		new DefaultShell("Testing shell");
 		new LabeledText("Test label1").setText("funny text");
 		assertEquals("funny text", new LabeledText("Test label1").getText());
+		assertEquals(1, modifiedCount);
+	}
+	
+	@Test
+	public void typeTextTest(){
+		new DefaultShell("Testing shell");
+		new LabeledText("Test label1").typeText("not so funny text");
+		assertEquals("not so funny text", new LabeledText("Test label1").getText());
+		assertEquals(18, modifiedCount);
 	}
 
 	@Test(expected = SWTLayerException.class)


### PR DESCRIPTION
There are situations when widget.setText is not sufficient because it doesn't trigger the same events as keyboard typing does. We should either provide method typeText simulating keyboard pressing or reimplement setText method (better approach IMHO).
