### PR TITLE
Review and update missing javadoc for org.jboss.reddeer.jface  plugin

### DIFF
--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/preference/FoldingPreferencePage.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/preference/FoldingPreferencePage.java
@@ -3,85 +3,150 @@ package org.jboss.reddeer.eclipse.jface.preference;
 import org.jboss.reddeer.swt.impl.button.CheckBox;
 
 /**
- * Class represents folding preference page Java -> Editor -> Folding
+ * Class represents folding preference page in preference shell.
  * 
  * @author jjankovi
- *
+ * @since 0.5
  */
 public class FoldingPreferencePage extends PreferencePage {
 
+	/**
+	 * Constructor which open folding preference in preference shell.
+	 */
 	public FoldingPreferencePage() {
 		super("Java", "Editor", "Folding");
 	}
 	
+	/**
+	 * Check whether folding is enabled or not.
+	 * 
+	 * @return true if folding is enabled, false otherwise
+	 */
 	public boolean isFoldingChecked() {
 		return new CheckBox(0).isChecked();
 	}
 	
+	/**
+	 * Enable folding. If folding is enabled, nothing happen.
+	 */
 	public void enableFolding() {
 		new CheckBox(0).toggle(true);
 	}
 	
+	/**
+	 * Disable folding. If folding is disabled, nothing happen.
+	 */
 	public void disableFolding() {
 		new CheckBox(0).toggle(false);
 	}
 	
+	/**
+	 * Check whether folding of comments is enabled or not.
+	 * 
+	 * @return true if folding of comments is enabled, false otherwise
+	 */
 	public boolean isCommentsChecked() {
 		return new CheckBox(1).isChecked();
 	}
 	
+	/**
+	 * Enable comments folding. If comments folding is enabled, nothing happen.
+	 */
 	public void enableComments() {
 		new CheckBox(1).toggle(true);
 	}
 	
+	/**
+	 * Disable comments folding. If comments folding is disabled, nothing happen.
+	 */
 	public void disableComments() {
 		new CheckBox(1).toggle(false);
 	}
 	
+	/**
+	 * Check whether header comments are folding or not.
+	 * @return true if header comments are folding, false otherwise
+	 */
 	public boolean isHeaderCommentsChecked() {
 		return new CheckBox(2).isChecked();
 	}
 	
+	/** 
+	 * Enable header comments folding. If header comments folding is enabled, nothing happen.
+	 */
 	public void enableHeaderComments() {
 		new CheckBox(2).toggle(true);
 	}
 	
+	/**
+	 * Disable header comments folding. If header comments folding is disabled, nothing happen.
+	 */
 	public void disableHeaderComments() {
 		new CheckBox(2).toggle(false);
 	}
 	
+	/**
+	 * Check whether inner types are folding or not.
+	 * @return true if inner types are folding, false otherwise
+	 */
 	public boolean isInnerTypesChecked() {
 		return new CheckBox(3).isChecked();
 	}
 
+	/**
+	 * Enable inner types folding. If inner types folding is enabled, nothing happen.
+	 */
 	public void enableInnerTypes() {
 		new CheckBox(3).toggle(true);
 	}
 	
+	/**
+	 * Disable inner types folding. If inner types folding is disabled, nothing happen.
+	 */
 	public void disableInnerTypes() {
 		new CheckBox(3).toggle(false);
 	}
 	
+	/**
+	 * Check whether members are folding or not.
+	 * @return true if members are folding, false otherwise
+	 */
 	public boolean isMembersChecked() {
 		return new CheckBox(4).isChecked();
 	}
 
+	/**
+	 * Enable members folding. If members folding is enabled, nothing happen.
+	 */
 	public void enableMembers() {
 		new CheckBox(4).toggle(true);
 	}
 	
+	/**
+	 * Disable members folding. If members folding is disabled, nothing happen.
+	 */
 	public void disableMembers() {
 		new CheckBox(4).toggle(false);
 	}
 	
+	/**
+	 * Check whether imports folding is enabled or not.
+	 * @return true if import folding is enabled, false otherwise
+	 */
 	public boolean isImportsChecked() {
 		return new CheckBox(5).isChecked();
 	}
 
+	/**
+	 * Enable imports folding. If imports folding is enabled, nothing happen.
+	 */
 	public void enableImports() {
 		new CheckBox(5).toggle(true);
 	}
 	
+	/**
+	 * Disable imports folding. If imports folding is disabled, nothing happen.
+	 */
 	public void disableImports() {
 		new CheckBox(5).toggle(false);
 	}

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/preference/PreferencePage.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/preference/PreferencePage.java
@@ -15,10 +15,11 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
 /**
- * Represents a general preference page in the Preferences dialog. Subclasses
+ * Represents a general preference page in the Preferences shell. Subclasses
  * should represent the concrete preference page.
  * 
  * @author Lucia Jelinkova
+ * @since 0.5
  * 
  */
 public abstract class PreferencePage {
@@ -28,10 +29,17 @@ public abstract class PreferencePage {
 	private String[] path;
 	protected final Logger log = Logger.getLogger(this.getClass());
 
+	/**
+	 * Constructor set path to specific preference item. 
+	 * @param path path in preference shell tree to specific preference
+	 */
 	public PreferencePage(String... path) {
 		this.path = path;
 	}
 
+	/**
+	 * Open preference shell and specific preference page in preference shell defined by path given in constructor.
+	 */
 	public void open() {
 
 		// if preferences dialog is not open, open it
@@ -63,29 +71,46 @@ public abstract class PreferencePage {
 		
 	}
 
+	/**
+	 * Get name of the given preference page.
+	 * 
+	 * @return name of preference page
+	 */
 	public String getName() {
 		DefaultCLabel cl = new DefaultCLabel();
 		return cl.getText();
 	}
 
+	/**
+	 * Submit OK button and exit preference shell.
+	 */
 	public void ok() {
 		Button b = new PushButton("OK");
 		log.info("Close Preferences dialog");
 		b.click();
 	}
 
+	/**
+	 * Submit Cancel button and exit preference shell.
+	 */
 	public void cancel() {
 		Button b = new PushButton("Cancel");
 		log.info("Cancel Preferences dialog");
 		b.click();
 	}
 
+	/**
+	 * Apply preference page changes.
+	 */
 	public void apply() {
 		Button b = new PushButton("Apply");
 		log.info("Apply changes in Preferences dialog");
 		b.click();
 	}
 
+	/**
+	 * Restore default preference page settings.
+	 */
 	public void restoreDefaults() {
 		Button b = new PushButton("Restore Defaults");
 		log.info("Restore default values in Preferences dialog");

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/ExportWizardDialog.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/ExportWizardDialog.java
@@ -6,12 +6,17 @@ package org.jboss.reddeer.eclipse.jface.wizard;
  * and selects an appropriate wizard in the dialog. 
  *   
  * @author Lucia Jelinkova
+ * @since 0.5
  *
  */
 public abstract class ExportWizardDialog extends TopMenuWizardDialog {
 
 	public static final String DIALOG_TITLE = "Export";
 	
+	/**
+	 * Constructor set path to specific export item in export dialog.
+	 * @param path
+	 */
 	public ExportWizardDialog(String... path) {
 		super(path);
 	}

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/ImportWizardDialog.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/ImportWizardDialog.java
@@ -6,12 +6,17 @@ package org.jboss.reddeer.eclipse.jface.wizard;
  * and selects an appropriate wizard in the dialog. 
  *   
  * @author Lucia Jelinkova
+ * @since 0.5
  *
  */
 public abstract class ImportWizardDialog extends TopMenuWizardDialog {
 
 	public static final String DIALOG_TITLE = "Import";
 	
+	/**
+	 * Constructor set path to the specific import item in import dialog.
+	 * @param path to the specific item in import dialog
+	 */
 	public ImportWizardDialog(String... path) {
 		super(path);
 	}

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/NewWizardDialog.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/NewWizardDialog.java
@@ -6,12 +6,17 @@ package org.jboss.reddeer.eclipse.jface.wizard;
  * and selects an appropriate wizard in the dialog. 
  * 
  * @author vpakan
+ * @since 0.5
  *
  */
 public abstract class NewWizardDialog extends TopMenuWizardDialog {
 	
 	public static final String DIALOG_TITLE = "New";
 	
+	/**
+	 * Constructor set path to the specific item in new wizard dialog.
+	 * @param path to the specific item in new wizard dialog
+	 */
 	public NewWizardDialog(String... path) {
 		super(path);
 	}

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/TopMenuWizardDialog.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/TopMenuWizardDialog.java
@@ -9,12 +9,18 @@ import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
  * It opens the wizard and selects an appropriate wizard in the dialog. 
  *   
  * @author Lucia Jelinkova
+ * @since 0.5
  *
  */
 public abstract class TopMenuWizardDialog extends WizardDialog {
 
 	private String[] path;
 	
+	/**
+	 * Constructor set path in wizard dialog for specific item.
+	 * @param path to the specific wizard dialog item in dialog shell
+	 * @throws IllegalArgumentException when path is empty
+	 */
 	public TopMenuWizardDialog(String... path) {
 		if (path.length == 0){
 			throw new IllegalArgumentException("Wizard path cannot be empty");
@@ -22,10 +28,21 @@ public abstract class TopMenuWizardDialog extends WizardDialog {
 		this.path = path;
 	}
 	
+	/**
+	 * Get dialog title on the given wizard dialog.
+	 * @return title of wizard dialog
+	 */
 	protected abstract String getDialogTitle();
 	
+	/**
+	 * Get path to the given wizard dialog from shell menu.
+	 * @return path to the specific wizard dialog
+	 */
 	protected abstract String[] getMenuPath();
 	
+	/**
+	 * Open wizard dialog defined by menu path and select the specific item.
+	 */
 	public void open(){
 		log.info("Opening wizard using top menu ");
 		currentPage = -1;

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardDialog.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardDialog.java
@@ -22,6 +22,7 @@ import org.jboss.reddeer.swt.wait.WaitWhile;
  * 
  * @author Lucia Jelinkova
  * @author apodhrad
+ * @since 0.5
  * 
  */
 public class WizardDialog {
@@ -60,7 +61,7 @@ public class WizardDialog {
 	/**
 	  * Returns a current wizard page
 	 * 
-	 * @return current wizard page
+	 * @return current wizard page or null when there is not any wizard page
 	 */
 
 	public WizardPage getCurrentWizardPage() {
@@ -131,6 +132,9 @@ public class WizardDialog {
 		wizardPageMap.put(page, allOf(new WizardPageIndex(pageIndex), matcher));
 	}
 
+	/**
+	 * Click the finish button in wizard dialog.
+	 */
 	public void finish() {
 		log.info("Finish wizard");
 
@@ -143,6 +147,9 @@ public class WizardDialog {
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 	}
 
+	/**
+	 * Click the cancel button in wizard dialog.
+	 */
 	public void cancel() {
 		log.info("Cancel wizard");
 
@@ -154,6 +161,9 @@ public class WizardDialog {
 		new WaitWhile(new JobIsRunning());
 	}
 
+	/**
+	 * Click the next button in wizard dialog.
+	 */
 	public void next() {
 		log.info("Go to next wizard page");
 
@@ -162,6 +172,9 @@ public class WizardDialog {
 		currentPage++;
 	}
 
+	/**
+	 * Click the back button in wizard dialog.
+	 */
 	public void back() {
 		log.info("Go to previous wizard page");
 		Button button = new PushButton("< Back");
@@ -169,6 +182,10 @@ public class WizardDialog {
 		currentPage--;
 	}
 
+	/**
+	 * Go to the specific page of wizard dialog. First wizard dialog page has index 0.
+	 * @param pageIndex of desired wizard page
+	 */
 	public void selectPage(int pageIndex) {
 		if (pageIndex != currentPage) {
 			boolean goBack = pageIndex < currentPage;
@@ -182,6 +199,10 @@ public class WizardDialog {
 		}
 	}
 
+	/**
+	 * Get page index of current wizard page.
+	 * @return current wizard page index
+	 */
 	public int getPageIndex() {
 		return currentPage;
 	}

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPage.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPage.java
@@ -3,9 +3,10 @@ package org.jboss.reddeer.eclipse.jface.wizard;
 import org.jboss.reddeer.junit.logging.Logger;
 
 /**
- * Wizard page
+ * Superclass of wizard page represent single page in wizard dialog.
  * 
  * @author apodhrad
+ * @since 0.5
  * 
  */
 public abstract class WizardPage {
@@ -33,10 +34,19 @@ public abstract class WizardPage {
 
 	}
 
+	/**
+	 * Set wizard dialog for specific wizard page.
+	 * 
+	 * @param wizardDialog set wizard dialog where this wizard page belong
+	 */
 	public void setWizardDialog(WizardDialog wizardDialog) {
 		this.wizardDialog = wizardDialog;
 	}
 
+	/**
+	 * Get wizard dialog of specific wizard page
+	 * @return WizardDialog of specific wizard page
+	 */
 	public WizardDialog getWizardDialog() {
 		return wizardDialog;
 	}

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPageIndex.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPageIndex.java
@@ -7,19 +7,22 @@ import org.hamcrest.Description;
  * Matches a wizard dialog with a given page index
  * 
  * @author apodhrad
+ * @since 0.5
  * 
  */
 public class WizardPageIndex extends BaseMatcher<WizardDialog> {
 
 	private int pageIndex;
 
+	/**
+	 * Constructor set page index for wizard dialog.
+	 * @param pageIndex in wizard dialog
+	 */
 	public WizardPageIndex(int pageIndex) {
 		this.pageIndex = pageIndex;
 	}
 
-	/**
-	 * Returns true if the wizard dialog is in a given page index
-	 */
+
 	@Override
 	public boolean matches(Object item) {
 		if (item instanceof WizardDialog) {

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPageProperty.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/wizard/WizardPageProperty.java
@@ -7,6 +7,7 @@ import org.hamcrest.Description;
  * Matches a wizard dialog with a given property
  * 
  * @author apodhrad
+ * @since 0.5
  * 
  */
 public class WizardPageProperty extends BaseMatcher<WizardDialog> {
@@ -19,9 +20,6 @@ public class WizardPageProperty extends BaseMatcher<WizardDialog> {
 		this.value = value;
 	}
 
-	/**
-	 * Returns true if a wizard dialog contains a given property
-	 */
 	@Override
 	public boolean matches(Object item) {
 		if (item instanceof WizardDialog) {


### PR DESCRIPTION
Review and update missing javadoc

all public members (classes, methods, etc.) should contains javadoc
user should be able able to understand behaviour from description without analyzing the code
use since (for example since 0.5 means <0.5-snapshot...0.6)
use deprecated with referencing the replacement
