### PR TITLE
Review and update missing javadoc for org.jboss.reddeer.requirements plugin

### DIFF
--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/Activator.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/Activator.java
@@ -8,7 +8,9 @@ import org.osgi.framework.BundleContext;
  */
 public class Activator extends AbstractUIPlugin {
 
-	// The plug-in ID
+	/**
+	 *  The plug-in ID
+	 */
 	public static final String PLUGIN_ID = "org.jboss.reddeer.requirements"; //$NON-NLS-1$
 
 	// The shared instance
@@ -16,6 +18,7 @@ public class Activator extends AbstractUIPlugin {
 	
 	/**
 	 * The constructor
+	 *
 	 */
 	public Activator() {
 	}

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/cleanworkspace/CleanWorkspaceRequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/cleanworkspace/CleanWorkspaceRequirement.java
@@ -1,5 +1,6 @@
 package org.jboss.reddeer.requirements.cleanworkspace;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,23 +13,42 @@ import org.jboss.reddeer.junit.requirement.Requirement;
 import org.jboss.reddeer.requirements.cleanworkspace.CleanWorkspaceRequirement.CleanWorkspace;
 
 /**
- * This requirement ensures, that all projects are deleted from workspace (aka. workspace is clean)
+ * Clean workspace requirement<br/><br/>
+ * 
+ * This {@link Requirement} ensures, that all projects are deleted from workspace
+ * (aka. workspace is clean).<br/><br>
+ * 
+ * Annotate test class with {@link CleanWorkspace} annotation to have clean
+ * workspace before the test cases are executed.<br/><br/>
+ * 
+ * Example:<br/>
+ * <pre>
+ * {@code @CleanWorkspace
+ * public class TestClass {
+ *    // workspace will be cleaned before tests execution
+ * }
+ * }
+ * </pre>
  * 
  * @author rhopp
  * 
  */
-
 public class CleanWorkspaceRequirement implements Requirement<CleanWorkspace> {
 
-	
+	/**
+	 * Marks test class, which requires clean workspace before test cases are executed.
+	 */
 	@Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
-	public @interface CleanWorkspace{
+	@Documented
+	public @interface CleanWorkspace {
 		
 	}
 	
 	/**
-	 * This should be possible every time.
+	 * Always returns true because cleaning workspace should be possible every time.
+	 * 
+	 * @return true
 	 */
 	@Override
 	public boolean canFulfill() {
@@ -36,9 +56,8 @@ public class CleanWorkspaceRequirement implements Requirement<CleanWorkspace> {
 	}
 
 	/**
-	 * Deletes all projects from workspace
+	 * Deletes all projects from workspace.
 	 */
-	
 	@Override
 	public void fulfill() {	
 		PackageExplorer packageExplorer = new PackageExplorer();
@@ -49,6 +68,11 @@ public class CleanWorkspaceRequirement implements Requirement<CleanWorkspace> {
 		}
 	}
 
+	/**
+	 * This method is empty because annotation {@link CleanWorkspace} has no elements.
+	 * However, it is one of methods of {@link Requirement} interface so it has to be
+	 * overridden.
+	 */
 	@Override
 	public void setDeclaration(CleanWorkspace declaration) {
 		// nothing to do here

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/exception/RequirementsLayerException.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/exception/RequirementsLayerException.java
@@ -1,21 +1,36 @@
 package org.jboss.reddeer.requirements.exception;
 
 /**
- * Thrown when some error appeared on requirements layer. Typically when
+ * Thrown when some error had appeared on requirements layer. Typically when
  * requirement couldn't be fulfilled (even though canFulfill returned true)
  * 
  * @author rhopp
  */
-
 public class RequirementsLayerException extends RuntimeException {
 
 	private static final long serialVersionUID = 6490745570893239529L;
 	
-
+	/**
+	 * Constructs a new requirements layer exception with the specified detail
+	 * message.
+	 * 
+	 * @param message the specified detail message
+	 * 
+	 * @see RuntimeException#RuntimeException(String)
+	 */
 	public RequirementsLayerException(String message) {
 		super(message);
 	}
 	
+	/**
+	 * Constructs a new requirements layer exception with the specified detail
+	 * message and cause.
+	 * 
+	 * @param message the specified detail message
+	 * @param cause the cause
+	 * 
+	 * @see RuntimeException#RuntimeException(String, Throwable)
+	 */
 	public RequirementsLayerException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/openperspective/OpenPerspectiveRequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/openperspective/OpenPerspectiveRequirement.java
@@ -1,5 +1,6 @@
 package org.jboss.reddeer.requirements.openperspective;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,25 +14,48 @@ import org.jboss.reddeer.requirements.exception.RequirementsLayerException;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 
 /**
- * This requirement ensures, that given perspective is active before actual test
- * execution.
+ * Open perspective requirement<br/><br/>
  * 
+ * This {@link Requirement} ensures, that given perspective is active before actual test
+ * execution.<br/><br/>
+ * 
+ * Annotate test class with {@link OpenPerspective} annotation to have
+ * the given perspective opened before the test cases are executed.<br/><br/>
+ * 
+ * Example:<br/>
+ * <pre>
+ * {@code @OpenPerspective(DebugPerspective.class)
+ * public class TestClass {
+ *    // debug perspective will be opened before tests execution
+ * }
+ * }
+ * </pre>
  * @author rhopp
  * 
  */
-
 public class OpenPerspectiveRequirement implements Requirement<OpenPerspective> {
 
+	/**
+	 * Marks test class, which requires opening of the specified perspective.
+	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
+	@Documented
 	public @interface OpenPerspective {
-
+		/**
+		 * specified perspective
+		 */
 		Class<? extends AbstractPerspective> value();
 	}
 
 	private OpenPerspective openPerspective;
 	private final Logger log = Logger.getLogger(this.getClass());
 
+	/**
+	 * Tests if a new instance of the given perspective can be created.
+	 * 
+	 * @return true if the given perspective is valid, otherwise false
+	 */
 	@Override
 	public boolean canFulfill() {
 		try {
@@ -49,6 +73,11 @@ public class OpenPerspectiveRequirement implements Requirement<OpenPerspective> 
 		return true;
 	}
 
+	/**
+	 * Opens the given perspective.
+	 * 
+	 * @throws RequirementsLayerException when the given perspective can't be opened
+	 */
 	@Override
 	public void fulfill() {
 		try {
@@ -59,6 +88,11 @@ public class OpenPerspectiveRequirement implements Requirement<OpenPerspective> 
 		}
 	}
 
+	/**
+	 * Sets perspective, which will be opened before actual test execution.
+	 * 
+	 * @param openPerspective annotation defining the perspective to be opened
+	 */
 	@Override
 	public void setDeclaration(OpenPerspective openPerspective) {
 		this.openPerspective = openPerspective;


### PR DESCRIPTION
Review and update missing javadoc

all public members (classes, methods, etc.) should contains javadoc
user should be able able to understand behaviour from description without analyzing the code
use since (for example since 0.5 means <0.5-snapshot...0.6)
use deprecated with referencing the replacement
