### PR TITLE
RepoConnectionDialogTest failing

### DIFF
--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -71,6 +71,16 @@
 							<artifactId>org.eclipse.wst.web.ui</artifactId>
 							<version>0.0.0</version>
 						</dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.mylyn.ide_feature.feature.group</artifactId>
+                            <version>0.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.mylyn.bugzilla_feature.feature.group</artifactId>
+                            <version>0.0.0</version>
+                        </dependency>
 					</dependencies>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
The test is failing because it expects the Eclipse.org repo to be present in Task repositories but it is not. 
