### PR TITLE
apodhrad_Failing contextMenuItemTextTest due to NPE

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/MenuLookup.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/MenuLookup.java
@@ -240,6 +240,10 @@ public class MenuLookup {
 	public MenuItem[] getTopMenuMenuItemsFromFocus() {
 
 		final Control control  = WidgetLookup.getInstance().getFocusControl();
+		if (control == null) {
+			throw new SWTLayerException(
+					"No control has focus. Perhaps something has stolen it? Try to regain focus with for example \"new DefaultShell()\".");
+		}
 		MenuItem[] items = null;
 		final Menu menu = getControlMenu(control);
 		

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/MenuTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/MenuTest.java
@@ -113,9 +113,12 @@ public class MenuTest extends RedDeerTest {
 	
 	@Test 
 	public void contextMenuItemTextTest() {
+		//make sure shell is focused
+		new DefaultShell();
+		
 		ProjectExplorer pe = new ProjectExplorer();
 		pe.open();
-
+		
 		Menu menu = new ContextMenu("New","Project...");
 		assertTrue("Menuitem text not expected to be empty", !menu.getText().equals(""));
 	}


### PR DESCRIPTION
see RedDeer_master_matrix/216/jdk=sunjdk1.6,label=stable-linux/testReport/org.jboss.reddeer.swt.test/MenuTest/contextMenuItemTextTest_default/

Error Message

Failed to execute runnable (java.lang.NullPointerException)
Stacktrace

org.eclipse.swt.SWTException: Failed to execute runnable (java.lang.NullPointerException)
    at org.eclipse.swt.SWT.error(SWT.java:4441)
    at org.eclipse.swt.SWT.error(SWT.java:4356)
    at org.eclipse.swt.widgets.Synchronizer.syncExec(Synchronizer.java:205)
    at org.eclipse.ui.internal.UISynchronizer.syncExec(UISynchronizer.java:150)
    at org.eclipse.swt.widgets.Display.syncExec(Display.java:4559)
    at org.jboss.reddeer.swt.util.Display.syncExec(Display.java:68)
    at org.jboss.reddeer.swt.lookup.MenuLookup.getControlMenu(MenuLookup.java:337)
    at org.jboss.reddeer.swt.lookup.MenuLookup.getTopMenuMenuItemsFromFocus(MenuLookup.java:244)
    at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:45)
    at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:36)
    at org.jboss.reddeer.swt.test.MenuTest.contextMenuItemTextTest(MenuTest.java:119)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:91)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
    at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
    at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:85)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:72)
    at java.lang.Thread.run(Thread.java:662)
Caused by: java.lang.NullPointerException
    at org.jboss.reddeer.swt.lookup.MenuLookup$12.run(MenuLookup.java:341)
    at org.jboss.reddeer.swt.lookup.MenuLookup$12.run(MenuLookup.java:1)
    at org.jboss.reddeer.swt.util.Display$1.run(Display.java:72)
    at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
    at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:136)
    at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3746)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3394)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1122)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1006)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:146)
    at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:615)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:566)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:125)
    at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:114)
    at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:109)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:80)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:372)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:226)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:636)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:591)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1450)
    at org.eclipse.equinox.launcher.Main.main(Main.java:1426)
