### PR TITLE
apodhrad_Exception is thrown inside of syncexec block

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/MenuLookup.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/MenuLookup.java
@@ -318,12 +318,16 @@ public class MenuLookup {
 				log.info("Getting Menu Bar of shell " + s.getText());
 				Menu menu = s.getMenuBar();
 				if (menu == null){
-					throw new SWTLayerException("Cannot find a menu bar of shell " + s.getText());
+					return null;
 				}
 				MenuItem[] items = menu.getItems();
 				return items;
 			}
 		});
+		if(items == null){
+			String shellText = WidgetHandler.getInstance().getText(s);
+			throw new SWTLayerException("Cannot find a menu bar of shell " + shellText);
+		}
 		return items;
 	}
 


### PR DESCRIPTION
due to this, exception is hard to read
