### PR TITLE
rawagner_Refactor WidgetHandler 

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ActionContributionItemHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ActionContributionItemHandler.java
@@ -4,6 +4,10 @@ import org.eclipse.jface.action.ActionContributionItem;
 import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
+/**
+ * Contains methods that handle UI operations on {@link ActionContributionItem} widgets. 
+ *
+ */
 public class ActionContributionItemHandler {
 	
 	private static ActionContributionItemHandler handler;
@@ -28,7 +32,4 @@ public class ActionContributionItemHandler {
 			}
 		});
 	}
-	
-	
-
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/BrowserHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/BrowserHandler.java
@@ -8,13 +8,33 @@ import org.jboss.reddeer.swt.util.ResultRunnable;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 
 /**
- * Handles Browser UI actions
+ * Contains methods that handle UI operations on {@link org.eclipse.swt.browser.Browser} widgets. 
  * @author Vlado Pakan
  *
  */
 public class BrowserHandler {
+
+	private static BrowserHandler instance;
+
+	private BrowserHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of TreeHandler class
+	 * 
+	 * @return
+	 */
+	public static BrowserHandler getInstance() {
+		if (instance == null) {
+			instance = new BrowserHandler();
+		}
+		return instance;
+	}
+	
 	/**
 	 * See {@link Browser}
+	 * @deprecated Use non static method instead
 	 * @param browser
 	 * @return
 	 */
@@ -29,6 +49,7 @@ public class BrowserHandler {
 	}
 	/**
 	 * See {@link Browser}
+	 * @deprecated Use non static method instead
 	 * @param browser
 	 * @return
 	 */
@@ -38,6 +59,7 @@ public class BrowserHandler {
 	}
 	/**
 	 * See {@link Browser}
+	 * @deprecated Use non static method instead
 	 * @param browser
 	 * @return
 	 */
@@ -52,6 +74,7 @@ public class BrowserHandler {
 	/**
 	 * See {@link Browser}
 	 * @param browser
+	 * @deprecated Use non static method instead
 	 * @return
 	 */
 	public static boolean back (final Browser browser){
@@ -64,6 +87,7 @@ public class BrowserHandler {
 	}
 	/**
 	 * See {@link Browser}
+	 * @deprecated Use non static method instead
 	 * @param browser
 	 * @return
 	 */
@@ -77,6 +101,7 @@ public class BrowserHandler {
 	}
 	/**
 	 * Adds progress listener to browser
+	 * @deprecated Use non static method instead
 	 * @param browser
 	 * @param progressListener
 	 */
@@ -90,6 +115,7 @@ public class BrowserHandler {
 	}
 	/**
 	 * Removes progress listener from browser
+	 * @deprecated Use non static method instead
 	 * @param browser
 	 * @param progressListener
 	 */
@@ -103,6 +129,7 @@ public class BrowserHandler {
 	}
 	/**
 	 * See {@link Browser}
+	 * @deprecated Use non static method instead
 	 * @param browser
 	 * @return
 	 */
@@ -111,6 +138,110 @@ public class BrowserHandler {
 			@Override
 			public Boolean run() {
 				return browser.getSWTWidget().setUrl(url);
+			}
+		});
+		
+		return result;
+	}
+	
+	/**
+	 * See {@link Browser}
+	 * @param browser
+	 * @return
+	 */
+	public String getURL (final org.eclipse.swt.browser.Browser browser) {
+		return Display.syncExec(new ResultRunnable<String>() {
+			@Override
+			public String run() {
+				return browser.getUrl();
+			}
+		});
+	}
+
+	/**
+	 * See {@link Browser}
+	 * @param browser
+	 * @return
+	 */
+	public String getText (final org.eclipse.swt.browser.Browser browser) {
+		return WidgetHandler.getInstance().getText(browser);
+	}
+	
+	/**
+	 * See {@link Browser}
+	 * @param browser
+	 * @return
+	 */
+	public void refresh (final org.eclipse.swt.browser.Browser browser){
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				browser.refresh();
+			}
+		});
+	}
+	/**
+	 * See {@link Browser}
+	 * @param browser
+	 * @return
+	 */
+	public boolean back (final org.eclipse.swt.browser.Browser browser){
+		return Display.syncExec(new ResultRunnable<Boolean>() {
+			@Override
+			public Boolean run() {
+				return browser.back();
+			}
+		});
+	}
+	/**
+	 * See {@link Browser}
+	 * @param browser
+	 * @return
+	 */
+	public boolean forward (final org.eclipse.swt.browser.Browser browser){
+		return Display.syncExec(new ResultRunnable<Boolean>() {
+			@Override
+			public Boolean run() {
+				return browser.forward();
+			}
+		});
+	}
+	/**
+	 * Adds progress listener to browser
+	 * @param browser
+	 * @param progressListener
+	 */
+	public void addProgressListener (final org.eclipse.swt.browser.Browser browser , final ProgressListener progressListener){
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				browser.addProgressListener(progressListener);
+			}
+		});
+	}
+	/**
+	 * Removes progress listener from browser
+	 * @param browser
+	 * @param progressListener
+	 */
+	public void removeProgressListener (final org.eclipse.swt.browser.Browser browser , final ProgressListener progressListener){
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				browser.removeProgressListener(progressListener);
+			}
+		});
+	}
+	/**
+	 * See {@link Browser}
+	 * @param browser
+	 * @return
+	 */
+	public boolean setURL (final org.eclipse.swt.browser.Browser browser , final String url) {
+		boolean result = Display.syncExec(new ResultRunnable<Boolean>() {
+			@Override
+			public Boolean run() {
+				return browser.setUrl(url);
 			}
 		});
 		

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ButtonHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ButtonHandler.java
@@ -1,0 +1,118 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Widget;
+import org.jboss.reddeer.swt.lookup.WidgetLookup;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+
+/**
+ * Contains methods that handle UI operations on {@link Button} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class ButtonHandler {
+
+	private static ButtonHandler instance;
+
+	private ButtonHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ButtonHandler class
+	 * 
+	 * @return
+	 */
+	public static ButtonHandler getInstance() {
+		if (instance == null) {
+			instance = new ButtonHandler();
+		}
+		return instance;
+	}
+	
+	/**
+	 * Click the {@link Button}
+	 * 
+	 * @param w given widgets
+	 */
+	public void click(final Button button) {
+		
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+					if (((button.getStyle() & SWT.TOGGLE) != 0) ||
+						((button.getStyle() & SWT.CHECK) != 0)) {
+						button.setSelection(!button.getSelection());
+					}
+			}
+		});
+		
+		WidgetLookup.getInstance().sendClickNotifications(button);
+		
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				if (!button.isDisposed()){
+					handleNotSelectedRadioButton(button);
+				}
+			}
+			
+			private void handleNotSelectedRadioButton(final Button button) {
+				if ((button.getStyle() & SWT.RADIO) == 0
+						|| button.getSelection()) {
+					return;
+				}
+
+				deselectSelectedSiblingRadio(button);
+				selectRadio(button);
+			}
+
+			private void deselectSelectedSiblingRadio(final Button button) {
+				if ((button.getParent().getStyle() & SWT.NO_RADIO_GROUP) != 0) {
+					return;
+				}
+				
+				Widget[] siblings = button.getParent().getChildren();
+				for (Widget widget : siblings) {
+					if (widget instanceof Button) {
+						Button sibling = (Button) widget;
+						if ((sibling.getStyle() & SWT.RADIO) != 0 && 
+								sibling.getSelection()) {
+							WidgetLookup.getInstance().notify(SWT.Deactivate, sibling);
+							sibling.setSelection(false);
+						}
+					}	
+				}
+			}
+			
+			private void selectRadio(Button button) {
+				WidgetLookup.getInstance().notify(SWT.Activate, button);
+				WidgetLookup.getInstance().notify(SWT.MouseDown, button);
+				WidgetLookup.getInstance().notify(SWT.MouseUp, button);
+				button.setSelection(true);
+				WidgetLookup.getInstance().notify(SWT.Selection, button);
+			}
+
+		});
+	}
+	
+	/**
+	 * Checks if button is selected
+	 * 
+	 * @param w	given widget
+	 * @return	returns widget label text
+	 */
+	public boolean isSelected(final Button button) {
+		boolean selectionState = Display.syncExec(new ResultRunnable<Boolean>() {
+			
+			@Override
+			public Boolean run() {
+				return button.getSelection();
+			}
+		});
+		return selectionState;
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/CTabFolderHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/CTabFolderHandler.java
@@ -1,0 +1,41 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.swt.custom.CTabFolder;
+import org.jboss.reddeer.swt.util.Display;
+
+
+/**
+ * Contains methods that handle UI operations on {@link CTabFolderHandler} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class CTabFolderHandler {
+
+	private static CTabFolderHandler instance;
+
+	private CTabFolderHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ComboHandler class
+	 * 
+	 * @return
+	 */
+	public static CTabFolderHandler getInstance() {
+		if (instance == null) {
+			instance = new CTabFolderHandler();
+		}
+		return instance;
+	}
+
+	public void setFocus(final CTabFolder folder) {
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				folder.forceFocus(); 
+			}
+		});
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/CTabItemHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/CTabItemHandler.java
@@ -12,13 +12,15 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
 /**
- * CTabItem handler handles operations for SWT CTabItem instances
+ * Contains methods that handle UI operations on {@link CTabItem} widgets. 
+ * 
  * @author Vlado Pakan
  *
  */
 public class CTabItemHandler {
+
+	private static final Logger logger = Logger.getLogger(CTabItemHandler.class);
 	
-	private final Logger logger = Logger.getLogger(this.getClass());	  
 	private static CTabItemHandler instance;
 
 	private CTabItemHandler() {
@@ -48,7 +50,7 @@ public class CTabItemHandler {
 		}
 		return instance;
 	}
-	
+
 	/**
 	 * Creates event for CTabItem with specified type
 	 * 
@@ -129,7 +131,7 @@ public class CTabItemHandler {
 		event.count = count;
 		return event;
 	}
-	
+
 	public boolean isShowClose(final CTabItem swtCTabItem) {
 		return Display.syncExec(new ResultRunnable<Boolean>() {
 			public Boolean run() {
@@ -145,6 +147,15 @@ public class CTabItemHandler {
 		Display.syncExec(new Runnable() {
 			public void run() {
 				swtCTabItem.getParent().setSelection(swtCTabItem);
+			}
+		});
+	}
+
+	public void setFocus(final CTabItem ctabItem) {
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				ctabItem.getParent().forceFocus();
 			}
 		});
 	}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ComboHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ComboHandler.java
@@ -1,0 +1,144 @@
+package org.jboss.reddeer.swt.handler;
+
+import java.util.Arrays;
+
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Widget;
+import org.jboss.reddeer.junit.logging.Logger;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+
+/**
+ * Contains methods that handle UI operations on {@link Combo} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class ComboHandler {
+
+	private static ComboHandler instance;
+
+	private final Logger log = Logger.getLogger(this.getClass());
+
+	private ComboHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ComboHandler class
+	 * 
+	 * @return
+	 */
+	public static ComboHandler getInstance() {
+		if (instance == null) {
+			instance = new ComboHandler();
+		}
+		return instance;
+	}
+
+	/**
+	 * Gets items
+	 * 
+	 * @param combo
+	 *            given widget
+	 * @return array of items in widget
+	 */
+	public String[] getItems(final Combo combo) {
+		return Display.syncExec(new ResultRunnable<String[]>() {
+
+			@Override
+			public String[] run() {
+				return combo.getItems();
+			}
+		});
+	}
+
+	/**
+	 * Sets selection with given index for supported widget type
+	 * 
+	 * @param index
+	 */
+	public <T extends Widget> void setSelection(final Combo combo, final int index) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				int itemsLength = getItems(combo).length;
+				if (index >= itemsLength) {
+					log.error("Combo does not have " + index + 1 + "items!");
+					log.info("Combo has " + itemsLength + " items");
+					throw new SWTLayerException("Nonexisted item in combo was requested");
+				} else {
+					combo.select(index);
+				}
+			}
+		});
+	}
+
+	/**
+	 * Sets selection with given text for supported widget type
+	 * 
+	 * @param index
+	 */
+	public void setSelection(final Combo combo, final String text) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				String[] items = getItems(combo);
+				int index = Arrays.asList(items).indexOf(text); 
+				if (index == -1) {
+					log.error("'" + text + "' is not "
+							+ "contained in combo items");
+					log.info("Items present in combo:");
+					int i = 0;
+					for (String item : items) {
+						log.info("    " + item + "(index " + i);
+						i++;
+					}
+					throw new SWTLayerException("Nonexisting item in combo was requested");
+				}else {
+					combo.select(index);
+				}
+			}
+		});
+	}
+
+	/**
+	 * Gets selection text for supported widget type
+	 * 
+	 * @param index
+	 */
+	public String getSelection(final Combo combo) {
+		return Display.syncExec(new ResultRunnable<String>() {
+
+			@Override
+			public String run() {
+				Point selection = combo.getSelection();
+				String comboText = combo.getText();
+				String selectionText = "";
+				if (selection.y > selection.x){
+					selectionText = comboText.substring(selection.x , selection.y);
+				}
+				return selectionText;
+			}
+		});
+	}
+	
+	/**
+	 * Gets selection index for supported widget type
+	 * 
+	 * @param index
+	 */
+	public <T extends Widget> int getSelectionIndex(final Combo combo) {
+		return Display.syncExec(new ResultRunnable<Integer>() {
+
+			@Override
+			public Integer run() {
+					return combo.getSelectionIndex();
+			}
+		});
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ExpandBarHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ExpandBarHandler.java
@@ -10,13 +10,34 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
 /**
- * Implements ExpandBar UI methods
+ * Contains methods that handle UI operations on {@link org.eclipse.swt.widgets.ExpandBar} widgets. 
+ * 
  * @author Vlado Pakan
  *
  */
 public class ExpandBarHandler {
+	
+	private static ExpandBarHandler instance;
+
+	private ExpandBarHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ComboHandler class
+	 * 
+	 * @return
+	 */
+	public static ExpandBarHandler getInstance() {
+		if (instance == null) {
+			instance = new ExpandBarHandler();
+		}
+		return instance;
+	}
+	
 	/**
 	 * See {@link ExpandBar}
+	 * @deprecated This is not UI handling operation, it should be moved to the widget's impl
 	 */
 	public static void expandAll(final ExpandBar expandBar) {
 		for (ExpandBarItem expandBarItem : expandBar.getItems()){
@@ -26,6 +47,7 @@ public class ExpandBarHandler {
 	}
 	/**
 	 * See {@link ExpandBar}
+	 * @deprecated This is not UI handling operation, it should be moved to the widget's impl
 	 */
 	public static void collapseAll(final ExpandBar expandBar) {
 		for (ExpandBarItem expandBarItem : expandBar.getItems()){
@@ -34,6 +56,7 @@ public class ExpandBarHandler {
 	}
 	/**
 	 * See {@link ExpandBar}
+	 * @deprecated Method should use SWT widget as its argument and should not be static
 	 */
 	public static List<ExpandBarItem> getItems(final ExpandBar expandBar) {
 		return Display.syncExec(new ResultRunnable<List<ExpandBarItem>>() {
@@ -47,8 +70,25 @@ public class ExpandBarHandler {
 		      }
 		    });
 	}
+	
 	/**
 	 * See {@link ExpandBar}
+	 */
+	public List<ExpandBarItem> getItems(final org.eclipse.swt.widgets.ExpandBar expandBar) {
+		return Display.syncExec(new ResultRunnable<List<ExpandBarItem>>() {
+		      @Override
+		      public List<ExpandBarItem> run() {
+		        LinkedList<ExpandBarItem> result = new LinkedList<ExpandBarItem>();
+		        for (org.eclipse.swt.widgets.ExpandItem swtExpandItem : expandBar.getItems()){
+		          result.addFirst(new BasicExpandBarItem(swtExpandItem));
+		        }
+		        return result;
+		      }
+		    });
+	}
+	/**
+	 * See {@link ExpandBar}
+	 * @deprecated This is not UI handling operation, it should be moved to the widget's impl
 	 */
 	public static int getItemsCount(final ExpandBar expandBar) {
 		return ExpandBarHandler.getItems(expandBar).size();

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ExpandBarItemHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ExpandBarItemHandler.java
@@ -1,20 +1,44 @@
 package org.jboss.reddeer.swt.handler;
 
-import org.jboss.reddeer.junit.logging.Logger;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.ExpandBar;
+import org.eclipse.swt.widgets.ExpandItem;
+import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.api.ExpandBarItem;
 import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
 import org.jboss.reddeer.swt.wait.AbstractWait;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 
 /**
- * Implements ExpandBarItem UI methods
+ * Contains methods that handle UI operations on {@link ExpandItem} widgets.  
+ *  
  * @author Vlado Pakan
  *
  */
 public class ExpandBarItemHandler {
+
 	private static final Logger logger = Logger.getLogger(ExpandBarItemHandler.class);
+
+	private static ExpandBarItemHandler instance;
+
+	private ExpandBarItemHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ComboHandler class
+	 * 
+	 * @return
+	 */
+	public static ExpandBarItemHandler getInstance() {
+		if (instance == null) {
+			instance = new ExpandBarItemHandler();
+		}
+		return instance;
+	}
+
 	/**
 	 * See {@link ExpandBarItem}
 	 * @param timePeriod
@@ -53,7 +77,7 @@ public class ExpandBarItemHandler {
 				}
 			});
 			ExpandBarItemHandler.notifyExpandBar(
-				ExpandBarItemHandler.createEventForExpandBar(SWT.Collapse,expandBarItem),expandBarItem);
+					ExpandBarItemHandler.createEventForExpandBar(SWT.Collapse,expandBarItem),expandBarItem);
 			logger.info("Expand Bar Item " + expandBarItem.getText()
 					+ " has been collapsed");
 		} else {
@@ -104,5 +128,124 @@ public class ExpandBarItemHandler {
 		event.widget = expandBarItem.getSWTParent();
 		event.detail = detail;
 		return event;
+	}
+
+	/**
+	 * See {@link ExpandBarItem}
+	 * @param timePeriod
+	 * @param expandBarItem
+	 */
+	public void expand(final ExpandItem expandItem, final ExpandBar expandBar) {
+		notifyExpandBar(createEventForExpandBar(SWT.Expand,expandItem, expandBar),expandBar);
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				expandItem.setExpanded(true);
+			}
+		});
+	}
+	/**
+	 * See {@link ExpandBarItem}
+	 * @param expandBarItem
+	 */
+	public void collapse(final ExpandItem expandItem, final ExpandBar expandBar) {
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				expandItem.setExpanded(false);
+			}
+		});
+		notifyExpandBar(createEventForExpandBar(SWT.Collapse,expandItem, expandBar),expandBar);
+	}
+
+	/**
+	 * Notifies Expand Bar listeners about event event.type field has too be properly
+	 * set
+	 * 
+	 * @param event
+	 * @param expandBarItem
+	 */
+	private void notifyExpandBar(final Event event, final ExpandBar expandBar) {
+		Display.syncExec(new Runnable() {
+			public void run() {
+				expandBar.notifyListeners(event.type, event);
+			}
+		});
+	}
+	/**
+	 * Creates event for Expand Bar with specified type and empty detail
+	 * 
+	 * @param type
+	 * @param expandBarItem
+	 * @return
+	 */
+	private Event createEventForExpandBar(int type , ExpandItem expandItem, ExpandBar expandBar) {
+		return createEventForExpandBar(type, SWT.NONE , expandItem, expandBar);
+	}
+
+	/**
+	 * Creates event for Expand Bar with specified type and detail
+	 * 
+	 * @param type
+	 * @param detail
+	 * @param expandBarItem
+	 * @return
+	 */
+	private Event createEventForExpandBar(int type, int detail , ExpandItem expandItem, ExpandBar expandBar) {
+		Event event = new Event();
+		event.type = type;
+		event.display = Display.getDisplay();
+		event.time = (int) System.currentTimeMillis();
+		event.item = expandItem;
+		event.widget = expandBar;
+		event.detail = detail;
+		return event;
+	}
+
+	/**
+	 * Gets tooltip if supported widget type
+	 * 
+	 * @param widget
+	 * @return widget text
+	 */
+	public String getToolTipText(final ExpandItem item) {
+		String text = Display.syncExec(new ResultRunnable<String>() {
+			@Override
+			public String run() {
+				return item.getParent().getToolTipText();
+			}
+		});
+		return text;
+	}
+
+	/**
+	 * Checks if supported widget is expanded
+	 * 
+	 * @param item	given widget
+	 * @return	true if widget is expanded
+	 */
+	public boolean isExpanded(final ExpandItem item) {
+		return Display.syncExec(new ResultRunnable<Boolean>() {
+
+			@Override
+			public Boolean run() {
+				return item.getExpanded();
+			}
+		});
+	}
+
+	/**
+	 * Returns parent for supported widget
+	 * 
+	 * @param item	given widget
+	 * @return	parent widget
+	 */
+	public ExpandBar getParent(final ExpandItem item) {
+		return Display.syncExec(new ResultRunnable<ExpandBar>() {
+			@Override
+			public ExpandBar run() {
+				return item.getParent();
+			}
+		});
 	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/LinkHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/LinkHandler.java
@@ -1,11 +1,13 @@
 package org.jboss.reddeer.swt.handler;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Link;
+import org.jboss.reddeer.swt.lookup.WidgetLookup;
 import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
 /**
- * Implements Link UI methods. 
+ * Contains methods that handle UI operations on {@link Link} widgets. 
  * 
  * @author Lucia Jelinkova
  *
@@ -29,18 +31,35 @@ public class LinkHandler {
 		}
 		return instance;
 	}
-	
+
 	public String getText(final Link l){
-		
+
 		String linkText = Display.syncExec(new ResultRunnable<String>() {
 			@Override
 			public String run() {
 				return l.getText();
 			}
 		});
-		
+
 		String[] split1 = linkText.split(".*<[aA]>");
 		String[] split2 = split1[split1.length-1].split("</[aA]>.*");
 		return split2[0];
+	}
+
+	/**
+	 * Activates widget - link/hyperlink etc
+	 * @param w widget to activate
+	 */
+	public void activate(final Link link) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				link.setFocus();
+				WidgetLookup.getInstance().notify(SWT.MouseDown, link);
+				WidgetLookup.getInstance().notify(SWT.Selection, link);
+				WidgetLookup.getInstance().notify(SWT.MouseUp, link);
+			}
+		});
 	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ListHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ListHandler.java
@@ -1,0 +1,171 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.List;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.lookup.WidgetLookup;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+
+/**
+ * Contains methods that handle UI operations on {@link List} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class ListHandler {
+
+	private static ListHandler instance;
+
+	private ListHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ListHandler class
+	 * 
+	 * @return
+	 */
+	public static ListHandler getInstance() {
+		if (instance == null) {
+			instance = new ListHandler();
+		}
+		return instance;
+	}
+
+	/**
+	 * Gets items
+	 * 
+	 * @param list
+	 *            given widget
+	 * @return array of items in widget
+	 */
+	public String[] getItems(final List list) {
+		return Display.syncExec(new ResultRunnable<String[]>() {
+
+			@Override
+			public String[] run() {
+				return list.getItems();
+			}
+		});
+	}
+
+	/**
+	 * Deselects all items
+	 * 
+	 * @param list given widget
+	 */
+	public void deselectAll(final List list) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				list.deselectAll();
+			}
+		});
+	}
+
+	public void selectAll(final List list) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if((list.getStyle() & SWT.MULTI) !=0){
+					list.selectAll();
+					WidgetLookup.getInstance().notify(SWT.Selection, list);
+				} else {
+					throw new SWTLayerException("List does not support multi selection - it does not have SWT MULTI style");
+				}
+			}
+		});
+	}
+
+	/**
+	 * Selects item for supported widget type
+	 * 
+	 * @param w given widget
+	 * @param item to select
+	 */
+	public void select(final List list,final String item) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				int index = (list.indexOf(item))	;
+				if(index == -1){
+					throw new SWTLayerException("Unable to select item "+item+" because it does not exist");
+				}
+				list.select(list.indexOf(item));
+				WidgetLookup.getInstance().sendClickNotifications(list);
+			}
+		});
+	}
+
+	/**
+	 * Selects items for supported widget type if widget supports multi selection
+	 * 
+	 * @param w given widget
+	 * @param items to select
+	 */
+	public void select(final List list,final String[] items) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if((list.getStyle() & SWT.MULTI) !=0){
+					for(String item:items){
+						int index = (list.indexOf(item))	;
+						if(index == -1){
+							throw new SWTLayerException("Unable to select item "+item+" because it does not exist");
+						}
+						list.select(list.indexOf(item));
+						WidgetLookup.getInstance().notify(SWT.Selection, list);
+					}
+				} else {
+					throw new SWTLayerException("List does not support multi selection - it does not have SWT MULTI style");
+				}
+			}
+		});
+	}
+
+	/**
+	 * Selects items for supported widget type if widget supports multi selection
+	 * 
+	 * @param w given widget
+	 * @param indices of items to select
+	 */
+	public void select(final List list,final int[] indices) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if((list.getStyle() & SWT.MULTI) !=0){
+					list.select(indices);
+					WidgetLookup.getInstance().notify(SWT.Selection, list);
+				} else {
+					throw new SWTLayerException("List does not support multi selection - it does not have SWT MULTI style");
+				}
+			}
+		});
+	}
+
+	/**
+	 * Selects item for supported widget type
+	 * 
+	 * @param w given widget
+	 * @param index of item to select
+	 */
+	public void select(final List list,final int index) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if(list.getItemCount()-1 < index){
+					throw new SWTLayerException("Unable to select item with index "+index+" because it does not exist");
+				}
+				list.select(index);
+				WidgetLookup.getInstance().notify(SWT.Selection, list);
+			}
+		});
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ScaleHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ScaleHandler.java
@@ -6,12 +6,32 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
 /**
- * Implements Scale UI methods
+ * Contains methods that handle UI operations on {@link org.eclipse.swt.widgets.Scale} widgets. 
  * @author Vlado Pakan
  *
  */
 public class ScaleHandler {
+	
+	private static ScaleHandler instance;
+
+	private ScaleHandler() {
+
+	}
+
 	/**
+	 * Creates and returns instance of TreeHandler class
+	 * 
+	 * @return
+	 */
+	public static ScaleHandler getInstance() {
+		if (instance == null) {
+			instance = new ScaleHandler();
+		}
+		return instance;
+	}
+	
+	/**
+	 * @deprecated The methods in handler should not be static and should use SWT widgets as arguments. Use ScaleHandler.getInstance and appropriate non static method
 	 * See {@link Scale}
 	 */
 	public static int getMinimum(final Scale scale) {
@@ -24,6 +44,7 @@ public class ScaleHandler {
 	}
 	/**
 	 * See {@link Scale}
+	 * @deprecated The methods in handler should not be static and should use SWT widgets as arguments. Use ScaleHandler.getInstance and appropriate non static method
 	 */
 	public static int getMaximum(final Scale scale) {
 		return Display.syncExec(new ResultRunnable<Integer>() {
@@ -34,6 +55,7 @@ public class ScaleHandler {
 		    });
 	}
 	/**
+	 * @deprecated The methods in handler should not be static and should use SWT widgets as arguments. Use ScaleHandler.getInstance and appropriate non static method
 	 * See {@link Scale}
 	 */
 	public static int getSelection(final Scale scale) {
@@ -45,6 +67,7 @@ public class ScaleHandler {
 		    });
 	}
 	/**
+	 * @deprecated The methods in handler should not be static and should use SWT widgets as arguments. Use ScaleHandler.getInstance and appropriate non static method
 	 * See {@link Scale}
 	 */
 	public static void setSelection(final Scale scale, final int value) {
@@ -57,4 +80,49 @@ public class ScaleHandler {
 		WidgetLookup.getInstance().sendClickNotifications(scale.getSWTWidget());
 	}
 	
+	/**
+	 * See {@link Scale}
+	 */
+	public int getMinimum(final org.eclipse.swt.widgets.Scale scale) {
+		return Display.syncExec(new ResultRunnable<Integer>() {
+		      @Override
+		      public Integer run() {
+		        return scale.getMinimum();
+		      }
+		    });
+	}
+	/**
+	 * See {@link Scale}
+	 */
+	public int getMaximum(final org.eclipse.swt.widgets.Scale scale) {
+		return Display.syncExec(new ResultRunnable<Integer>() {
+		      @Override
+		      public Integer run() {
+		        return scale.getMaximum();
+		      }
+		    });
+	}
+	/**
+	 * See {@link Scale}
+	 */
+	public int getSelection(final org.eclipse.swt.widgets.Scale scale) {
+		return Display.syncExec(new ResultRunnable<Integer>() {
+		      @Override
+		      public Integer run() {
+		        return scale.getSelection();
+		      }
+		    });
+	}
+	/**
+	 * See {@link Scale}
+	 */
+	public void setSelection(final org.eclipse.swt.widgets.Scale scale, final int value) {
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				scale.setSelection(value);
+			}
+		});
+		WidgetLookup.getInstance().sendClickNotifications(scale);
+	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ShellHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ShellHandler.java
@@ -4,12 +4,12 @@ import org.eclipse.swt.widgets.Shell;
 import org.jboss.reddeer.swt.util.Display;
 
 /**
- * Shell handler handles operations for SWT Shell instances
+ * Contains methods that handle UI operations on {@link Shell} widgets. 
  * @author Jiri Peterka
  *
  */
 public class ShellHandler {
-	  
+
 	private static ShellHandler instance;
 
 	private ShellHandler() {
@@ -27,7 +27,7 @@ public class ShellHandler {
 		}
 		return instance;
 	}
-	
+
 
 	/**
 	 * Closes given shell
@@ -45,4 +45,13 @@ public class ShellHandler {
 		});
 	}
 
+	public void setFocus(final Shell shell) {
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				shell.forceActive();
+				shell.forceFocus();
+			}
+		});
+	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/SpinnerHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/SpinnerHandler.java
@@ -1,0 +1,64 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.swt.widgets.Spinner;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+
+/**
+ * Contains methods that handle UI operations on {@link Spinner} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class SpinnerHandler {
+
+	private static SpinnerHandler instance;
+
+	private SpinnerHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ComboHandler class
+	 * 
+	 * @return
+	 */
+	public static SpinnerHandler getInstance() {
+		if (instance == null) {
+			instance = new SpinnerHandler();
+		}
+		return instance;
+	}
+
+	/**
+	 * Get value of supported widget
+	 * 
+	 * @param spinner widget
+	 * @return value of the widget
+	 */
+	public int getValue(final Spinner spinner) {
+		return Display.syncExec(new ResultRunnable<Integer>() {
+
+			@Override
+			public Integer run() {
+				return spinner.getSelection();
+			}
+		});
+	}
+
+	/**
+	 * Set value of supported widget
+	 * 
+	 * @param spinner widget
+	 * @param value value of the widget
+	 */
+	public void setValue(final Spinner spinner, final int value) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				spinner.setSelection(value);
+			}
+		});
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/StyledTextHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/StyledTextHandler.java
@@ -4,7 +4,7 @@ import org.eclipse.swt.custom.StyledText;
 import org.jboss.reddeer.swt.util.Display;
 
 /**
- * StyleTextHandler provides API for manipulation with with StyledText widget
+ * Contains methods that handle UI operations on {@link StyledText} widgets. 
  * @author Jiri Peterka
  *
  */

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TabFolderHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TabFolderHandler.java
@@ -6,7 +6,7 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
 /**
- * TabFolder handler handles operations for SWT TabFolder instances
+ * Contains methods that handle UI operations on {@link TabFolder} widgets. 
  * 
  * @author Andrej Podhradsky
  *
@@ -32,6 +32,15 @@ public class TabFolderHandler {
 			@Override
 			public TabItem[] run() {
 				return tabFolder.getItems();
+			}
+		});
+	}
+
+	public void setFocus(final TabFolder folder) {
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				folder.forceFocus(); 	
 			}
 		});
 	}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TabItemHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TabItemHandler.java
@@ -6,12 +6,12 @@ import org.eclipse.swt.widgets.TabItem;
 import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 /**
- * TabItem handler handles operations for SWT TabItem instances
+ * Contains methods that handle UI operations on {@link TabItem} widgets. 
  * @author Vlado Pakan
  *
  */
 public class TabItemHandler {
-	  
+
 	private static TabItemHandler instance;
 
 	private TabItemHandler() {
@@ -81,6 +81,15 @@ public class TabItemHandler {
 		Display.syncExec(new Runnable() {
 			public void run() {
 				swtTabItem.getParent().setSelection(swtTabItem);
+			}
+		});
+	}
+
+	public void setFocus(final TabItem tabItem) {
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				tabItem.getParent().forceFocus();
 			}
 		});
 	}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TableHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TableHandler.java
@@ -10,8 +10,12 @@ import org.jboss.reddeer.swt.lookup.WidgetLookup;
 import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
+/**
+ * 
+ * Contains methods that handle UI operations on {@link TableHandler} widgets. 
+ */
 public class TableHandler {
-	  
+
 	private static TableHandler instance;
 
 	private TableHandler() {
@@ -29,7 +33,7 @@ public class TableHandler {
 		}
 		return instance;
 	}
-	
+
 	public int rowCount(final Table table) {
 		return Display.syncExec(new ResultRunnable<Integer>() {
 
@@ -39,7 +43,7 @@ public class TableHandler {
 			}
 		});
 	}
-	
+
 	public boolean isGrayed(final TableItem tableItem) {
 		return Display.syncExec(new ResultRunnable<Boolean>() {
 
@@ -49,7 +53,7 @@ public class TableHandler {
 			}
 		});
 	}
-	
+
 	public Image getItemImage(final TableItem tableItem, final int imageIndex) {
 		return Display.syncExec(new ResultRunnable<Image>() {
 
@@ -59,11 +63,11 @@ public class TableHandler {
 			}
 		});
 	}
-	
+
 	public int indexOf(final Table table, final String item, final int columnIndex){
-		final TableItem[] tableItems = (TableItem[]) WidgetHandler.getInstance().getSWTItems(table);
-		
-		
+		final TableItem[] tableItems = getSWTItems(table);
+
+
 		for(int i=0;i<tableItems.length;i++){
 			final int y = i;
 			String itemText = Display.syncExec(new ResultRunnable<String>() {
@@ -73,27 +77,131 @@ public class TableHandler {
 					return  tableItems[y].getText(columnIndex);
 				}
 			});
-			
+
 			if(itemText.equals(item)){
 				return y;
 			}
 		}
 		throw new SWTLayerException("Item "+item+" does not exist in table");
 	}
-	
+
 	public void doubleClick(final TableItem tableItem, final int column){
 		Display.syncExec(new Runnable() {
-			
+
 			@Override
 			public void run() {
-				WidgetHandler.getInstance().select(tableItem);
+				TableItemHandler.getInstance().select(tableItem);
 				Rectangle rectangle = tableItem.getBounds(column);
 				int x = rectangle.x + (rectangle.width/2);
 				int y = rectangle.y + (rectangle.height/2);
 				WidgetLookup.getInstance().notifyItemMouse(SWT.MouseDoubleClick,SWT.NONE , tableItem.getParent(), tableItem, x, y, 1);
-				
+
 			}
 		});
 	}
 
+	/**
+	 * Gets swt items
+	 * 
+	 * @param table
+	 *            given widget
+	 * @return array of items in widget
+	 */
+	public TableItem[] getSWTItems(final Table table) {
+		return Display.syncExec(new ResultRunnable<TableItem[]>() {
+
+			@Override
+			public TableItem[] run() {
+				return table.getItems();
+			}
+		});
+	}
+
+	/**
+	 * Gets swt items wit specified index
+	 * 
+	 * @param table
+	 *            given widget
+	 * @return array of items in widget
+	 */
+	public TableItem getSWTItem(final Table table, final int index) {
+		return Display.syncExec(new ResultRunnable<TableItem>() {
+
+			@Override
+			public TableItem run() {
+				return table.getItem(index);
+			}
+		});
+	}
+
+	/**
+	 * Deselects all items 
+	 * 
+	 * @param w given widget
+	 */
+	public void deselectAll(final Table w) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				w.deselectAll();
+			}
+		});
+	}
+
+	public void selectAll(final Table table) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if((table.getStyle() & SWT.MULTI) !=0){
+					table.selectAll();
+					WidgetLookup.getInstance().notify(SWT.Selection, table);
+				} else {
+					throw new SWTLayerException("Table does not support multi selection - it does not have SWT MULTI style");
+				}
+			}
+		});
+	}
+
+	/**
+	 * Selects items for supported widget type if widget supports multi selection
+	 * 
+	 * @param w given widget
+	 * @param indices of items to select
+	 */
+	public void select(final Table table,final int[] indices) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if((table.getStyle() & SWT.MULTI) !=0){
+					table.select(indices);
+					WidgetLookup.getInstance().notify(SWT.Selection, table);
+				} else {
+					throw new SWTLayerException("Table does not support multi selection - it does not have SWT MULTI style");
+				}
+			}
+		});
+	}
+
+	/**
+	 * Selects item for supported widget type
+	 * 
+	 * @param w given widget
+	 * @param index of item to select
+	 */
+	public void select(final Table table,final int index) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if(table.getItemCount()-1 < index){
+					throw new SWTLayerException("Unable to select item with index "+index+" because it does not exist");
+				}
+				table.select(index);
+				WidgetLookup.getInstance().notify(SWT.Selection, table);
+			}
+		});
+	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TableItemHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TableItemHandler.java
@@ -1,0 +1,144 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableItem;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.lookup.WidgetLookup;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+
+/**
+ * Contains methods that handle UI operations on {@link TableItem} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class TableItemHandler {
+
+	private static TableItemHandler instance;
+
+	private TableItemHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ButtonHandler class
+	 * 
+	 * @return
+	 */
+	public static TableItemHandler getInstance() {
+		if (instance == null) {
+			instance = new TableItemHandler();
+		}
+		return instance;
+	}
+
+	/**
+	 * Checks if tableitem is selected
+
+	 * @param tableItem	given widget
+	 * @return	returns widget label text
+	 */
+	public boolean isSelected(final TableItem tableItem) {
+		boolean selectionState = Display.syncExec(new ResultRunnable<Boolean>() {
+
+			@Override
+			public Boolean run() {
+				for(TableItem i: tableItem.getParent().getSelection()){
+					if(i.equals(tableItem)){
+						return true;
+					}
+				}
+				return false;
+			}
+		});
+		return selectionState;
+	}
+
+	/**
+	 * Gets text on given cell index 
+	 * 
+	 * @param tableItem given widget
+	 * @Param cellIndex index of cell
+	 * @return returns widget text
+	 */
+	public String getText(final TableItem tableItem, final int cellIndex) {
+		String text = Display.syncExec(new ResultRunnable<String>() {
+			@Override
+			public String run() {
+				return tableItem.getText(cellIndex);
+			}
+		});
+		return text;
+	}
+
+	/**
+	 * Selects item for supported widget type
+	 * 
+	 * @param w given widget
+	 * @param item to select
+	 */
+	public void select(final TableItem swtTableItem) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				swtTableItem.getParent().setFocus();
+				swtTableItem.getParent().setSelection(swtTableItem);
+				WidgetLookup.getInstance().notifyItem(SWT.Selection, SWT.NONE, swtTableItem.getParent(), swtTableItem);
+			}
+		});
+	}
+
+	/**
+	 * Checks item for supported widget type
+	 * 
+	 * @param w given widget
+	 * @param item to check
+	 */
+	public <T> void setChecked(final TableItem swtTableItem, final boolean check) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if((swtTableItem.getParent().getStyle() & SWT.CHECK) != SWT.CHECK){
+					throw new SWTLayerException("Unable to check table item "+swtTableItem.getText()+" because table does not have SWT.CHECK style");
+				}
+				swtTableItem.getParent().setFocus();
+				swtTableItem.setChecked(check);
+				WidgetLookup.getInstance().notifyItem(SWT.Selection, SWT.CHECK, swtTableItem.getParent(), swtTableItem);
+			}
+		});
+	}
+
+	/**
+	 * Checks if widget is checked
+	 * 
+	 * @param w given widget
+	 */
+	public boolean isChecked(final TableItem swtTableItem) {
+		return Display.syncExec(new ResultRunnable<Boolean>() {
+
+			@Override
+			public Boolean run() {
+				return swtTableItem.getChecked();
+			}
+		});
+	}
+	
+	/**
+	 * Returns parent for supported widget
+	 * 
+	 * @param table	given widget
+	 * @return	parent widget
+	 */
+	public Table getParent(final TableItem table) {
+		return Display.syncExec(new ResultRunnable<Table>() {
+			@Override
+			public Table run() {
+				return table.getParent();
+			}
+		});
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TextHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TextHandler.java
@@ -1,0 +1,54 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.swt.widgets.Text;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.util.Display;
+
+/**
+ * Contains methods that handle UI operations on {@link Text} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class TextHandler {
+
+	private static TextHandler instance;
+
+	private TextHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ComboHandler class
+	 * 
+	 * @return
+	 */
+	public static TextHandler getInstance() {
+		if (instance == null) {
+			instance = new TextHandler();
+		}
+		return instance;
+	}
+
+	/**
+	 * Set text to {@link Text} if it is editable
+	 * 
+	 * @param w
+	 *            given widgets
+	 * @param text
+	 *            text to be set
+	 */
+	public void setText(final Text w, final String text) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				Text textField = (Text) w;
+				if(!textField.getEditable()) {
+					throw new SWTLayerException("Text field is not editable");
+				}
+				textField.setText(text);
+			}
+		});
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ToolItemHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/ToolItemHandler.java
@@ -1,0 +1,71 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.ToolItem;
+import org.jboss.reddeer.swt.lookup.WidgetLookup;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+
+
+/**
+ * Contains methods that handle UI operations on {@link ToolItem} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class ToolItemHandler {
+
+	private static ToolItemHandler instance;
+
+	private ToolItemHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ToolItemHandler class
+	 * 
+	 * @return
+	 */
+	public static ToolItemHandler getInstance() {
+		if (instance == null) {
+			instance = new ToolItemHandler();
+		}
+		return instance;
+	}
+
+	/**
+	 * Click the {@link ToolItem}
+	 * 
+	 * @param w given widgets
+	 */
+	public void click(final ToolItem toolItem) {
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				if (((toolItem.getStyle() & SWT.TOGGLE) != 0) ||
+						((toolItem.getStyle() & SWT.CHECK) != 0) ||
+						((toolItem.getStyle() & SWT.RADIO) != 0)) {
+					toolItem.setSelection(!toolItem.getSelection());
+				}
+			}
+		});
+
+		WidgetLookup.getInstance().sendClickNotifications(toolItem);
+	}
+	
+	/**
+	 * Checks if toolitem is selected
+
+	 * @param w	given widget
+	 * @return	returns widget label text
+	 */
+	public boolean isSelected(final ToolItem w) {
+		boolean selectionState = Display.syncExec(new ResultRunnable<Boolean>() {
+			@Override
+			public Boolean run() {
+					return w.getSelection(); 
+			}
+		});
+		return selectionState;
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TreeHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TreeHandler.java
@@ -21,7 +21,7 @@ import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 
 /**
- * Tree handler handles operations for SWT Tree and TreeItem instances
+ * Contains methods that handle UI operations on {@link org.eclipse.swt.widgets.Tree} widgets. 
  * 
  * @author Vlado Pakan
  * 

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TreeItemHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TreeItemHandler.java
@@ -1,0 +1,81 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.swt.widgets.TreeItem;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+
+/**
+ * Contains methods that handle UI operations on {@link TreeItem} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class TreeItemHandler {
+
+	private static TreeItemHandler instance;
+
+	private TreeItemHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ComboHandler class
+	 * 
+	 * @return
+	 */
+	public static TreeItemHandler getInstance() {
+		if (instance == null) {
+			instance = new TreeItemHandler();
+		}
+		return instance;
+	}
+
+	/**
+	 * Gets text on given cell index 
+	 * 
+	 * @param tableItem given widget
+	 * @Param cellIndex index of cell
+	 * @return returns widget text
+	 */
+	public String getText(final TreeItem tableItem, final int cellIndex) {
+		String text = Display.syncExec(new ResultRunnable<String>() {
+			@Override
+			public String run() {
+				return tableItem.getText(cellIndex);
+			}
+		});
+		return text;
+	}
+
+	/**
+	 * Gets tooltip if supported widget type
+	 * 
+	 * @param widget
+	 * @return widget text
+	 */
+	public String getToolTipText(final TreeItem item) {
+		String text = Display.syncExec(new ResultRunnable<String>() {
+			@Override
+			public String run() {
+				return item.getParent().getToolTipText();
+			}
+		});
+		return text;
+	}
+
+	/**
+	 * Checks if supported widget is expanded
+	 * 
+	 * @param item	given widget
+	 * @return	true if widget is expanded
+	 */
+	public boolean isExpanded(final TreeItem item) {
+		return Display.syncExec(new ResultRunnable<Boolean>() {
+
+			@Override
+			public Boolean run() {
+				return item.getExpanded();
+			}
+		});
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/WidgetHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/WidgetHandler.java
@@ -3,28 +3,22 @@ package org.jboss.reddeer.swt.handler;
 import java.util.Arrays;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.browser.Browser;
-import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
-import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.ExpandBar;
 import org.eclipse.swt.widgets.ExpandItem;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.List;
-import org.eclipse.swt.widgets.Scale;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
-import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
@@ -51,9 +45,9 @@ import org.jboss.reddeer.swt.util.ResultRunnable;
  * @author Jaroslav Jankovic
  */
 public class WidgetHandler {
-  
+
 	private final Logger log = Logger.getLogger(this.getClass());
-  
+
 	private static WidgetHandler instance;
 
 	private WidgetHandler() {
@@ -71,7 +65,7 @@ public class WidgetHandler {
 		}
 		return instance;
 	}
-	
+
 	/**
 	 * Checks if widget is enabled
 	 * @param widget
@@ -91,7 +85,7 @@ public class WidgetHandler {
 		}
 		return ret;
 	}
-	
+
 	/**
 	 * Checks if widget is visible
 	 * @param widget given widget
@@ -111,10 +105,10 @@ public class WidgetHandler {
 		}
 		return ret;
 	}
-	
+
 	/**
 	 * Click for supported widget type
-	 * 
+	 * @deprecated Use click() on the specific handlers
 	 * @param w given widgets
 	 */
 	public <T extends Widget> void click(final T w) {
@@ -124,14 +118,14 @@ public class WidgetHandler {
 				if (w instanceof Button) {
 					final Button button = (Button) w;
 					if (((button.getStyle() & SWT.TOGGLE) != 0) ||
-						((button.getStyle() & SWT.CHECK) != 0)) {
+							((button.getStyle() & SWT.CHECK) != 0)) {
 						button.setSelection(!button.getSelection());
 					}
 				}else if (w instanceof ToolItem) {
 					final ToolItem toolItem = (ToolItem) w;
 					if (((toolItem.getStyle() & SWT.TOGGLE) != 0) ||
-						((toolItem.getStyle() & SWT.CHECK) != 0) ||
-						((toolItem.getStyle() & SWT.RADIO) != 0)) {
+							((toolItem.getStyle() & SWT.CHECK) != 0) ||
+							((toolItem.getStyle() & SWT.RADIO) != 0)) {
 						toolItem.setSelection(!toolItem.getSelection());
 					}
 				}else {
@@ -168,7 +162,7 @@ public class WidgetHandler {
 				if ((button.getParent().getStyle() & SWT.NO_RADIO_GROUP) != 0) {
 					return;
 				}
-				
+
 				Widget[] siblings = button.getParent().getChildren();
 				for (Widget widget : siblings) {
 					if (widget instanceof Button) {
@@ -181,7 +175,7 @@ public class WidgetHandler {
 					}	
 				}
 			}
-			
+
 			private void selectRadio(Button button) {
 				WidgetLookup.getInstance().notify(SWT.Activate, button);
 				WidgetLookup.getInstance().notify(SWT.MouseDown, button);
@@ -192,7 +186,7 @@ public class WidgetHandler {
 
 		});
 	}
-	
+
 	/**
 	 * Gets style for supported widget type
 	 * 
@@ -212,16 +206,16 @@ public class WidgetHandler {
 		});
 		return style;
 	}
-	
+
 	/**
 	 * Checks if supported widget is selected
-	 * 
+	 * @deprecated Use specific handlers instead
 	 * @param w	given widget
 	 * @return	returns widget label text
 	 */
 	public <T extends Widget> boolean isSelected(final T w) {
 		boolean selectionState = Display.syncExec(new ResultRunnable<Boolean>() {
-			
+
 			@Override
 			public Boolean run() {
 				if (w instanceof Button)
@@ -250,31 +244,18 @@ public class WidgetHandler {
 	 * @param text
 	 *            text to be set
 	 */
-	public <T extends Widget> void setText(final T w, final String text) {
-		Display.syncExec(new Runnable() {
-
-			@Override
-			public void run() {
-				if (w instanceof Text) {
-					Text textField = (Text) w;
-					if(!textField.getEditable()) {
-						throw new SWTLayerException("Text field is not editable");
-					}
-					textField.setText(text);
-				}
-				else if (w instanceof StyledText)
-					((StyledText) w).setText(text);
-				else if (w instanceof Combo)
-          ((Combo) w).setText(text);
-        else
-					throw new SWTLayerException("Unsupported type");
-
-			}
-		});
+	public <T extends Widget> void setText(final T widget, final String text) {
+		Object o = null;
+		try {
+			ObjectUtil.invokeMethod(widget, "setText", new Class[]{String.class}, new Object[]{text});
+		} catch (RuntimeException e) {
+			throw new SWTLayerException("Runtime error during setting widget's text", e);
+		}
 	}
+
 	/**
 	 * Gets text on given cell index for supported widget type 
-	 * 
+	 * @deprecated Use concrete implementations instead
 	 * @param w given widget
 	 * @Param cellIndex index of cell
 	 * @return returns widget text
@@ -295,7 +276,7 @@ public class WidgetHandler {
 		});
 		return text;
 	}
-	
+
 	/**
 	 * Gets text for supported widget type
 	 * 
@@ -313,17 +294,17 @@ public class WidgetHandler {
 		if (o == null){
 			return null;
 		}
-		
+
 		if (o instanceof String) {
 			return (String) o;
 		}
-		
+
 		throw new SWTLayerException("Return value of method getText() on class " + o.getClass() + " should be String, but was " + o.getClass());
 	}
 
 	/**
 	 * Checks item for supported widget type
-	 * 
+	 * @deprecated Use concrete handler instead
 	 * @param w given widget
 	 * @param itemIndex item index to check
 	 */
@@ -339,7 +320,7 @@ public class WidgetHandler {
 					}
 					if((widget.getStyle() & SWT.CHECK) != SWT.CHECK){
 						throw new SWTLayerException("Unable to check item because table does not have SWT.CHECK style");
-						
+
 					} 
 					widget.getItem(itemIndex).setChecked(true);
 					WidgetLookup.getInstance().notifyItem(SWT.Selection, SWT.CHECK, widget, widget.getItem(itemIndex));
@@ -350,10 +331,10 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Gets items for supported widget type
-	 * 
+	 * @deprecated use concrete impl instead
 	 * @param w
 	 *            given widget
 	 * @return array of items in widget
@@ -366,17 +347,17 @@ public class WidgetHandler {
 				if (w instanceof List)
 					return ((List) w).getItems();
 				else if (w instanceof Combo)
-          return ((Combo) w).getItems();
+					return ((Combo) w).getItems();
 				else
 					throw new SWTLayerException("Unsupported type");
 			}
 		});
 		return text;
 	}
-	
+
 	/**
 	 * Gets swt items for supported widget type
-	 * 
+	 * @deprecated Use concrete handlers instead
 	 * @param w
 	 *            given widget
 	 * @return array of items in widget
@@ -393,10 +374,10 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Gets swt items for supported widget type
-	 * 
+	 * @deprecated Use concrete handlers instead
 	 * @param w
 	 *            given widget
 	 * @return array of items in widget
@@ -413,10 +394,10 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Deselects all items for supported widget type
-	 * 
+	 * @deprecated Use concrete handlers instead
 	 * @param w given widget
 	 */
 	public <T extends Widget> void deselectAll(final T w) {
@@ -433,10 +414,10 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Selects all items for supported widget type
-	 * 
+	 * @deprecated Use concrete handlers instead
 	 * @param w given widget
 	 */
 	public <T extends Widget> void selectAll(final T w) {
@@ -466,10 +447,10 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Selects item for supported widget type
-	 * 
+	 * @deprecated use concrete handler instead
 	 * @param w given widget
 	 * @param item to select
 	 */
@@ -500,16 +481,16 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Selects item for supported widget type
-	 * 
+	 * @deprecated use concrete handler instead
 	 * @param w given widget
 	 * @param item to select
 	 */
 	public <T> void select(final T wItem) {
 		Display.syncExec(new Runnable() {
-			
+
 			@Override
 			public void run() {
 				if(wItem instanceof TableItem){
@@ -523,16 +504,16 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Checks item for supported widget type
-	 * 
+	 * @deprecated use concrete handlers
 	 * @param w given widget
 	 * @param item to check
 	 */
 	public <T> void setChecked(final T wItem, final boolean check) {
 		Display.syncExec(new Runnable() {
-			
+
 			@Override
 			public void run() {
 				if(wItem instanceof TableItem){
@@ -549,15 +530,15 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Checks if widget is checked
-	 * 
+	 * @deprecated use concrete handlers instead
 	 * @param w given widget
 	 */
 	public <T> boolean isChecked(final T w) {
 		return Display.syncExec(new ResultRunnable<Boolean>() {
-			
+
 			@Override
 			public Boolean run() {
 				if(w instanceof TableItem){
@@ -569,10 +550,10 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Selects items for supported widget type if widget supports multi selection
-	 * 
+	 * @deprecated use concrete handlers instead
 	 * @param w given widget
 	 * @param items to select
 	 */
@@ -601,10 +582,10 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Selects items for supported widget type if widget supports multi selection
-	 * 
+	 * @deprecated use concrete handler instead
 	 * @param w given widget
 	 * @param indices of items to select
 	 */
@@ -636,10 +617,10 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Selects item for supported widget type
-	 * 
+	 * @deprecated use concrete handlers instead
 	 * @param w given widget
 	 * @param index of item to select
 	 */
@@ -676,7 +657,7 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 	/**
 	 * Gets label for supported widget type
 	 * 
@@ -688,29 +669,24 @@ public class WidgetHandler {
 
 			@Override
 			public String run() {
-				if ((w instanceof List) || (w instanceof Text) || (w instanceof Combo) || (w instanceof Spinner)) {
-					Widget parent = ((Control)w).getParent();;
-					java.util.List<Widget> children = WidgetResolver.getInstance().getChildren(parent);
-					for (int i = 1; i < children.size() ; i++) {						
-						if (children.get(i) != null && children.get(i).equals(w)) {
-							for(int y=1; i-y>=0 ;y++){
-								if(children.get(i - y) instanceof Label){
-									if(((Label)children.get(i - y)).getImage() == null){
-										return ((Label)children.get(i - y)).getText();
-									}
-								} else {
-									return null;
+				Widget parent = ((Control)w).getParent();;
+				java.util.List<Widget> children = WidgetResolver.getInstance().getChildren(parent);
+				for (int i = 1; i < children.size() ; i++) {						
+					if (children.get(i) != null && children.get(i).equals(w)) {
+						for(int y=1; i-y>=0 ;y++){
+							if(children.get(i - y) instanceof Label){
+								if(((Label)children.get(i - y)).getImage() == null){
+									return ((Label)children.get(i - y)).getText();
 								}
+							} else {
+								return null;
 							}
 						}
 					}
 				}
-				else {
-					throw new SWTLayerException("Unsupported type");
-				}
 				return null;
 			}}
-		);
+				);
 		if(label != null) {
 			label = label.replaceAll("&", "").split("\t")[0];
 		}
@@ -723,71 +699,61 @@ public class WidgetHandler {
 	 * @param widget
 	 * @return widget text
 	 */
-	public <T extends Widget> String getToolTipText(final T w) {
-		String text = Display.syncExec(new ResultRunnable<String>() {
-			@Override
-			public String run() {
-				if (w instanceof Text)
-					return ((Text) w).getToolTipText();
-				else if (w instanceof Combo)
-					return ((Combo) w).getToolTipText();
-				else if (w instanceof CTabItem)
-					return ((CTabItem) w).getToolTipText();
-				else if (w instanceof Button){
-					return ((Button) w).getToolTipText();
-				}else if (w instanceof ExpandItem)
-					return ((ExpandItem) w).getParent().getToolTipText();
-				else if (w instanceof CLabel){
-					return ((CLabel)w).getToolTipText();
-				}else if (w instanceof TreeItem){
-					return ((TreeItem)w).getParent().getToolTipText();
-				}else if (w instanceof ToolItem){
-					return ((ToolItem)w).getToolTipText();					
-				}else
-					throw new SWTLayerException("Unsupported type");
-			}
-		});
-		return text;
+	public <T extends Widget> String getToolTipText(final T widget) {
+		Object o = null;
+		try {
+			o = ObjectUtil.invokeMethod(widget, "getToolTipText");
+		} catch (RuntimeException e) {
+			throw new SWTLayerException("Runtime error during retrieving widget's text", e);
+		}
+		if (o == null){
+			return null;
+		}
+
+		if (o instanceof String) {
+			return (String) o;
+		}
+
+		throw new SWTLayerException("Return value of method getText() on class " + o.getClass() + " should be String, but was " + o.getClass());
 	}
-	
+
+	/**
+	 * Sets focus to the widget. The method is called from {@link WidgetLookup} so it need to be common for all widgets and cannot
+	 * be decomposed to separate handlers. 
+	 * @param w
+	 */
 	public <T extends Widget> void setFocus(final T w) {
-		Display.syncExec(new Runnable() {
-			@Override
-			public void run() {
-				if (w instanceof ExpandBar){
-					((ExpandBar)w).setFocus();
-				} else if (w instanceof Browser){
-					((Browser)w).setFocus();
-				} else if (w instanceof Scale){
-					((Scale)w).setFocus();
-				} else if(w instanceof CTabItem) {
-					CTabItem ctabItem = (CTabItem) w; 
-					ctabItem.getParent().forceFocus();
-				} else if(w instanceof CTabFolder) {
-					((CTabFolder) w).forceFocus(); 
-				}else if(w instanceof TabItem) {
-					TabItem tabItem = (TabItem) w; 
-					tabItem.getParent().forceFocus();
-				} else if(w instanceof TabFolder) {
-					((TabFolder) w).forceFocus(); 	
-				} else if(w instanceof Shell) {
-					Shell shell = (Shell) w; 
-					shell.forceActive();
-					shell.forceFocus();
-				} else if (w instanceof Control) {
-					((Control)w).setFocus();
-				} else throw new SWTLayerException("Unsupported type");
-			}
-		});
+
+		if(w instanceof CTabItem) {
+			CTabItemHandler.getInstance().setFocus((CTabItem) w);
+		} else if(w instanceof CTabFolder) {
+			CTabFolderHandler.getInstance().setFocus((CTabFolder) w); 
+		}else if(w instanceof TabItem) {
+			TabItemHandler.getInstance().setFocus((TabItem) w);
+		} else if(w instanceof TabFolder) {
+			TabFolderHandler.getInstance().setFocus((TabFolder) w);
+		} else if(w instanceof Shell) {
+			ShellHandler.getInstance().setFocus((Shell) w);
+		} else {
+			Display.syncExec(new Runnable() {
+				@Override
+				public void run() {
+					if (w instanceof Control) {
+						((Control)w).setFocus();
+					} else throw new SWTLayerException("Unsupported type");
+				}
+			});
+		}
 	}
-	
+
 	/**
 	 * Activates widget - link/hyperlink etc
+	 * @deprecated Use concrete handlers instead
 	 * @param w widget to activate
 	 */
 	public <T> void activate(final T w) {
 		Display.syncExec(new Runnable() {
-			
+
 			@Override
 			public void run() {
 				if (w instanceof Link) {
@@ -805,116 +771,116 @@ public class WidgetHandler {
 			}
 		});
 	}
-	 /**
-	  * Sets selection with given index for supported widget type
-	  * 
-	  * @param index
-	  */
-	 public <T extends Widget> void setSelection(final T w, final int index) {
-	   Display.syncExec(new Runnable() {
-	    
-	    @Override
-	    public void run() {
-	      if (w instanceof Combo) {
-	        int itemsLength = getItems(w).length;
-	        if (index >= itemsLength) {
-	          log.error("Combo does not have " + index + 1 + "items!");
-	          log.info("Combo has " + itemsLength + " items");
-	          throw new SWTLayerException("Nonexisted item in combo was requested");
-	        } else {
-	          ((Combo)w).select(index);
-	        }
-	      }
-	      else 
-	        throw new SWTLayerException("Unsupported type");
-	    }
-	  });
+	/**
+	 * Sets selection with given index for supported widget type
+	 * @deprecated please use concrete handlers
+	 * @param index
+	 */
+	public <T extends Widget> void setSelection(final T w, final int index) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if (w instanceof Combo) {
+					int itemsLength = getItems(w).length;
+					if (index >= itemsLength) {
+						log.error("Combo does not have " + index + 1 + "items!");
+						log.info("Combo has " + itemsLength + " items");
+						throw new SWTLayerException("Nonexisted item in combo was requested");
+					} else {
+						((Combo)w).select(index);
+					}
+				}
+				else 
+					throw new SWTLayerException("Unsupported type");
+			}
+		});
 	}
-	
+
 	/**
 	 * Sets selection with given text for supported widget type
-	 * 
+	 * @deprecated please use concrete handlers
 	 * @param index
 	 */
 	public <T extends Widget> void setSelection(final T w, final String text) {
-	  Display.syncExec(new Runnable() {
-	    
-	    @Override
-	    public void run() {
-	      if (w instanceof Combo) {
-	        String[] items = getItems(w);
-	        int index = Arrays.asList(items).indexOf(text); 
-	        if (index == -1) {
-	          log.error("'" + text + "' is not "
-	              + "contained in combo items");
-	          log.info("Items present in combo:");
-	          int i = 0;
-	          for (String item : items) {
-	            log.info("    " + item + "(index " + i);
-	            i++;
-	          }
-	          throw new SWTLayerException("Nonexisting item in combo was requested");
-	        }else {
-	          ((Combo)w).select(index);
-	        }
-	      }
-	    }
-	  });
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if (w instanceof Combo) {
+					String[] items = getItems(w);
+					int index = Arrays.asList(items).indexOf(text); 
+					if (index == -1) {
+						log.error("'" + text + "' is not "
+								+ "contained in combo items");
+						log.info("Items present in combo:");
+						int i = 0;
+						for (String item : items) {
+							log.info("    " + item + "(index " + i);
+							i++;
+						}
+						throw new SWTLayerException("Nonexisting item in combo was requested");
+					}else {
+						((Combo)w).select(index);
+					}
+				}
+			}
+		});
 	}
-	
+
 	/**
 	 * Gets selection text for supported widget type
-	 * 
+	 * @deprecated please use concrete handlers
 	 * @param index
 	 */
 	public <T extends Widget> String getSelection(final T w) {
-	  return Display.syncExec(new ResultRunnable<String>() {
-	    
-	    @Override
-	    public String run() {
-	      if (w instanceof Combo) {
-	    	Combo combo = (Combo)w;
-	    	Point selection = combo.getSelection();
-	    	String comboText = combo.getText();
-	    	String selectionText = "";
-	    	if (selection.y > selection.x){
-	    		selectionText = comboText.substring(selection.x , selection.y);
-	    	}
-	        return selectionText;
-	      }
-	      else 
-	        throw new SWTLayerException("Unsupported type");
-	    }
-	  });
+		return Display.syncExec(new ResultRunnable<String>() {
+
+			@Override
+			public String run() {
+				if (w instanceof Combo) {
+					Combo combo = (Combo)w;
+					Point selection = combo.getSelection();
+					String comboText = combo.getText();
+					String selectionText = "";
+					if (selection.y > selection.x){
+						selectionText = comboText.substring(selection.x , selection.y);
+					}
+					return selectionText;
+				}
+				else 
+					throw new SWTLayerException("Unsupported type");
+			}
+		});
 	}
-	 
+
 	/**
 	 * Gets selection index for supported widget type
-	 * 
+	 * @deprecated please use concrete handler instead
 	 * @param index
 	 */
 	public <T extends Widget> int getSelectionIndex(final T w) {
-	  return Display.syncExec(new ResultRunnable<Integer>() {
-	    
-	    @Override
-	    public Integer run() {
-	      if (w instanceof Combo) {
-	        return ((Combo)w).getSelectionIndex();
-	      }
-	      else 
-	        throw new SWTLayerException("Unsupported type");
-	    }
-	  });
+		return Display.syncExec(new ResultRunnable<Integer>() {
+
+			@Override
+			public Integer run() {
+				if (w instanceof Combo) {
+					return ((Combo)w).getSelectionIndex();
+				}
+				else 
+					throw new SWTLayerException("Unsupported type");
+			}
+		});
 	}
 	/**
 	 * Checks if supported widget is expanded
-	 * 
+	 * @deprecated Use custom handler instead
 	 * @param w	given widget
 	 * @return	true if widget is expanded
 	 */
 	public <T extends Widget> boolean isExpanded(final T w) {
 		boolean selectionState = Display.syncExec(new ResultRunnable<Boolean>() {
-			
+
 			@Override
 			public Boolean run() {
 				if (w instanceof ExpandItem)
@@ -929,7 +895,7 @@ public class WidgetHandler {
 	}
 	/**
 	 * Returns parent for supported widget
-	 * 
+	 * @deprecated Use concrete handler instead
 	 * @param w	given widget
 	 * @return	parent widget
 	 */
@@ -952,10 +918,11 @@ public class WidgetHandler {
 		});
 		return parent;
 	}
-	
+
 	/**
 	 * Get value of supported widget
 	 * 
+	 * @deprecated please use concrete handlers
 	 * @param w widget
 	 * @return value of the widget
 	 */
@@ -975,6 +942,7 @@ public class WidgetHandler {
 	/**
 	 * Set value of supported widget
 	 * 
+	 * @deprecated please use concrete handlers
 	 * @param w widget
 	 * @param value value of the widget
 	 */
@@ -990,5 +958,5 @@ public class WidgetHandler {
 			}
 		});
 	}
-	
+
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/WorkbenchHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/WorkbenchHandler.java
@@ -9,7 +9,7 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
 /**
- * 
+ * Contains methods that handle UI operations on {@link IWorkbench}. 
  * @author Jiri Peterka
  *
  */

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/browser/AbstractBrowser.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/browser/AbstractBrowser.java
@@ -31,7 +31,7 @@ public abstract class AbstractBrowser implements Browser{
 	@Override
 	public void forward() {
 		setUpProgressListener();
-		if (BrowserHandler.forward(this)){
+		if (BrowserHandler.getInstance().forward(this.getSWTWidget())){
 			new WaitUntil(new PageIsLoaded(this), TimePeriod.LONG);
 			// Unfortunately Browser needs some time to get ready even when page is fully loaded
 			AbstractWait.sleep(TimePeriod.SHORT.getSeconds() * 1000);
@@ -42,7 +42,7 @@ public abstract class AbstractBrowser implements Browser{
 	@Override
 	public void back() {
 		setUpProgressListener();
-		if (BrowserHandler.back(this)) {
+		if (BrowserHandler.getInstance().back(this.getSWTWidget())) {
 			new WaitUntil(new PageIsLoaded(this), TimePeriod.LONG);
 			// Unfortunately Browser needs some time to get ready even when page
 			// is fully loaded
@@ -54,7 +54,7 @@ public abstract class AbstractBrowser implements Browser{
 	@Override
 	public void setURL(String url) {
 		setUpProgressListener();
-		if (BrowserHandler.setURL(this , url)){
+		if (BrowserHandler.getInstance().setURL(this.getSWTWidget(), url)){
 			new WaitUntil(new PageIsLoaded(this), TimePeriod.LONG);
 			// Unfortunately Browser needs some time to get ready even when page is fully loaded
 			AbstractWait.sleep(TimePeriod.NORMAL.getSeconds() * 1000);
@@ -64,12 +64,14 @@ public abstract class AbstractBrowser implements Browser{
 	
 	@Override
 	public String getURL() {
-		return BrowserHandler.getURL(this);	
+		new WaitUntil(new PageIsLoaded(this));
+		return BrowserHandler.getInstance().getURL(this.getSWTWidget());	
 	}
 	
 	@Override
 	public String getText() {
-		return BrowserHandler.getText(this);	
+		new WaitUntil(new PageIsLoaded(this));
+		return BrowserHandler.getInstance().getText(this.getSWTWidget());	
 	}
 	/**
 	 * See {@link Browser}
@@ -80,14 +82,14 @@ public abstract class AbstractBrowser implements Browser{
 	}
 	@Override
 	public void refresh() {
-		BrowserHandler.refresh(this);		
+		BrowserHandler.getInstance().refresh(this.getSWTWidget());		
 	}
 	private void setUpProgressListener (){
-		BrowserHandler.addProgressListener(this, browserProgressListener);
+		BrowserHandler.getInstance().addProgressListener(this.getSWTWidget(), browserProgressListener);
 		browserProgressListener.setDone(false);
 	}
 	private void resetProgressListener (){
-		BrowserHandler.removeProgressListener(this, browserProgressListener);
+		BrowserHandler.getInstance().removeProgressListener(this.getSWTWidget(), browserProgressListener);
 		browserProgressListener.setDone(true);
 	}
 

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/AbstractButton.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/AbstractButton.java
@@ -10,6 +10,7 @@ import org.jboss.reddeer.direct.platform.RunningPlatform;
 import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.api.Button;
 import org.jboss.reddeer.swt.condition.WidgetIsEnabled;
+import org.jboss.reddeer.swt.handler.ButtonHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.lookup.ButtonLookup;
 import org.jboss.reddeer.swt.matcher.StyleMatcher;
@@ -64,7 +65,7 @@ public abstract class AbstractButton implements Button {
 						getToolTipText() != null ? getToolTipText()
 						: "with no text or tooltip")));
 		new WaitUntil(new WidgetIsEnabled(this));
-		WidgetHandler.getInstance().click(swtButton);
+		ButtonHandler.getInstance().click(swtButton);
 	}
 	
 	/**

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/CheckBox.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/CheckBox.java
@@ -1,8 +1,8 @@
 package org.jboss.reddeer.swt.impl.button;
 
-import org.jboss.reddeer.junit.logging.Logger;
 import org.eclipse.swt.SWT;
-import org.jboss.reddeer.swt.handler.WidgetHandler;
+import org.jboss.reddeer.junit.logging.Logger;
+import org.jboss.reddeer.swt.handler.ButtonHandler;
 import org.jboss.reddeer.swt.reference.ReferencedComposite;
 /**
  * Class represents Button with type Toggle (Checkbox)
@@ -90,7 +90,7 @@ public class CheckBox extends AbstractButton {
 	 * @return
 	 */
 	public boolean isChecked() {
-		return WidgetHandler.getInstance().isSelected(swtButton);
+		return ButtonHandler.getInstance().isSelected(swtButton);
 	}
 	
 	/**

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/RadioButton.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/RadioButton.java
@@ -1,8 +1,8 @@
 package org.jboss.reddeer.swt.impl.button;
 
-import org.jboss.reddeer.junit.logging.Logger;
 import org.eclipse.swt.SWT;
-import org.jboss.reddeer.swt.handler.WidgetHandler;
+import org.jboss.reddeer.junit.logging.Logger;
+import org.jboss.reddeer.swt.handler.ButtonHandler;
 import org.jboss.reddeer.swt.reference.ReferencedComposite;
 
 /**
@@ -85,7 +85,7 @@ public class RadioButton extends AbstractButton {
 	 * @return
 	 */
 	public boolean isSelected() {
-		return WidgetHandler.getInstance().isSelected(swtButton);
+		return ButtonHandler.getInstance().isSelected(swtButton);
 	}
 	/**
 	 * Sets Radio Button to state 'checked'

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/ToggleButton.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/button/ToggleButton.java
@@ -1,8 +1,8 @@
 package org.jboss.reddeer.swt.impl.button;
 
-import org.jboss.reddeer.junit.logging.Logger;
 import org.eclipse.swt.SWT;
-import org.jboss.reddeer.swt.handler.WidgetHandler;
+import org.jboss.reddeer.junit.logging.Logger;
+import org.jboss.reddeer.swt.handler.ButtonHandler;
 import org.jboss.reddeer.swt.reference.ReferencedComposite;
 /**
  * Toggle Button implementation
@@ -85,7 +85,7 @@ public class ToggleButton extends AbstractButton {
      * @return
      */
 	public boolean isSelected() {
-		return WidgetHandler.getInstance().isSelected(swtButton);
+		return ButtonHandler.getInstance().isSelected(swtButton);
 	}
 	/**
 	 * Sets Toggle Button to state 'checked'

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/combo/AbstractCombo.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/combo/AbstractCombo.java
@@ -4,6 +4,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.api.Combo;
+import org.jboss.reddeer.swt.handler.ComboHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.util.Display;
 
@@ -33,7 +34,7 @@ public abstract class AbstractCombo implements Combo {
 	public void setSelection(int index) {
 		log.info("Set selection of Combo " + getText() + " to index: "
 				+ index);
-		WidgetHandler.getInstance().setSelection(swtCombo, index);
+		ComboHandler.getInstance().setSelection(swtCombo, index);
 		notifyCombo(createEventForCombo(SWT.Selection));
 	}
 
@@ -44,7 +45,7 @@ public abstract class AbstractCombo implements Combo {
 	public void setSelection(String selection) {
 		log.info("Set selection of Combo " + getText() + " to selection: "
 				+ selection);
-		WidgetHandler.getInstance().setSelection(swtCombo, selection);
+		ComboHandler.getInstance().setSelection(swtCombo, selection);
 		notifyCombo(createEventForCombo(SWT.Selection));
 	}
 
@@ -53,7 +54,7 @@ public abstract class AbstractCombo implements Combo {
 	 */
 	@Override
 	public String getSelection() {
-		return WidgetHandler.getInstance().getSelection(swtCombo);
+		return ComboHandler.getInstance().getSelection(swtCombo);
 	}
 
 	/**
@@ -61,7 +62,7 @@ public abstract class AbstractCombo implements Combo {
 	 */
 	@Override
 	public int getSelectionIndex() {
-		return WidgetHandler.getInstance().getSelectionIndex(swtCombo);
+		return ComboHandler.getInstance().getSelectionIndex(swtCombo);
 	}
 
 	/**

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/expandbar/AbstractExpandBar.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/expandbar/AbstractExpandBar.java
@@ -33,14 +33,14 @@ public abstract class AbstractExpandBar implements ExpandBar {
 	 */
 	@Override
 	public int getItemsCount() {
-		return ExpandBarHandler.getItemsCount(this);
+		return ExpandBarHandler.getInstance().getItems(this.getSWTWidget()).size();
 	}
 	/**
 	 * See {@link ExpandBar}
 	 */
 	@Override
 	public List<ExpandBarItem> getItems() {
-		return ExpandBarHandler.getItems(this);
+		return ExpandBarHandler.getInstance().getItems(this.getSWTWidget());
 	}
 	/**
 	 * See {@link ExpandBar}
@@ -55,14 +55,18 @@ public abstract class AbstractExpandBar implements ExpandBar {
 	 */
 	@Override
 	public void expandAll() {
-		ExpandBarHandler.expandAll(this);
+		for (ExpandBarItem expandBarItem : getItems()){
+			expandBarItem.expand();
+		}
 	}
 	/**
 	 * See {@link ExpandBar}
 	 */
 	@Override
 	public void collapseAll() {
-		ExpandBarHandler.collapseAll(this);
+		for (ExpandBarItem expandBarItem : getItems()){
+			expandBarItem.collapse();
+		}
 	}
 	/**
 	 * See {@link ExpandBar}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/expandbar/AbstractExpandBarItem.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/expandbar/AbstractExpandBarItem.java
@@ -8,6 +8,7 @@ import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.handler.ExpandBarItemHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.impl.expandbar.internal.BasicExpandBar;
+import org.jboss.reddeer.swt.wait.AbstractWait;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 
 /**
@@ -26,7 +27,7 @@ public abstract class AbstractExpandBarItem implements ExpandBarItem {
 	protected AbstractExpandBarItem(final org.eclipse.swt.widgets.ExpandItem swtExpandItem) {
 		if (swtExpandItem != null) {
 			this.swtExpandItem = swtExpandItem;
-			this.swtParent = WidgetHandler.getInstance().getParent(swtExpandItem);
+			this.swtParent = ExpandBarItemHandler.getInstance().getParent(swtExpandItem);
 		} else {
 			throw new SWTLayerException(
 					"SWT Expand Item passed to constructor is null");
@@ -61,14 +62,31 @@ public abstract class AbstractExpandBarItem implements ExpandBarItem {
 	 */
 	@Override
 	public void expand(TimePeriod timePeriod) {
-		ExpandBarItemHandler.expand(timePeriod, this);
+		logger.debug("Expanding Expand Bar Item " + getText());
+		if (!isExpanded()) {
+			ExpandBarItemHandler.getInstance().expand(getSWTWidget(), getSWTParent());
+			AbstractWait.sleep(timePeriod.getSeconds()*1000);
+			logger.info("Expand Bar Item " + getText()
+					+ " has been expanded");
+		} else {
+			logger.debug("Expand Bar Item " + getText()
+					+ " is already expanded. No action performed");
+		}
 	}
 	/**
 	 * See {@link ExpandBarItem}
 	 */
 	@Override
 	public void collapse() {
-		ExpandBarItemHandler.collapse(this);
+		logger.debug("Collapsing Expand Bar Item " + getText());
+		if (isExpanded()) {
+			ExpandBarItemHandler.getInstance().collapse(getSWTWidget(), getSWTParent());
+			logger.info("Expand Bar Item " + getText()
+					+ " has been collapsed");
+		} else {
+			logger.debug("Expand Bar Item " + getText()
+					+ " is already collapsed. No action performed");
+		}
 	}
 	/**
 	 * Return swt widget of Expand Bar Item
@@ -101,7 +119,7 @@ public abstract class AbstractExpandBarItem implements ExpandBarItem {
 	 */
 	@Override
 	public boolean isExpanded() {
-		return WidgetHandler.getInstance().isExpanded(this.swtExpandItem);
+		return ExpandBarItemHandler.getInstance().isExpanded(this.swtExpandItem);
 	}
 	
 	@Override

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/link/AbstractLink.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/link/AbstractLink.java
@@ -16,7 +16,7 @@ public abstract class AbstractLink implements Link{
 	}
 	
 	public void click(){
-		WidgetHandler.getInstance().activate(link);
+		LinkHandler.getInstance().activate(link);
 	}
 	
 	public org.eclipse.swt.widgets.Link getSWTWidget(){

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/list/AbstractList.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/list/AbstractList.java
@@ -2,6 +2,7 @@ package org.jboss.reddeer.swt.impl.list;
 
 import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.api.List;
+import org.jboss.reddeer.swt.handler.ListHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 
 /**
@@ -17,31 +18,31 @@ public abstract class AbstractList implements List {
 	protected final Logger logger = Logger.getLogger(this.getClass());
 
 	public void select(String listItem) {
-		WidgetHandler.getInstance().select(list,listItem);
+		ListHandler.getInstance().select(list,listItem);
 	}
 
 	public void select(int listItemIndex) {
-		WidgetHandler.getInstance().select(list,listItemIndex);
+		ListHandler.getInstance().select(list,listItemIndex);
 	}
 
 	public String[] getListItems() {
-		return WidgetHandler.getInstance().getItems(list);
+		return ListHandler.getInstance().getItems(list);
 	}
 
 	public void deselectAll() {
-		WidgetHandler.getInstance().deselectAll(list);
+		ListHandler.getInstance().deselectAll(list);
 	}
 	
 	public void selectAll() {
-		WidgetHandler.getInstance().selectAll(list);
+		ListHandler.getInstance().selectAll(list);
 	}
 
 	public void select(String... listItems) {
-		WidgetHandler.getInstance().select(list,listItems);
+		ListHandler.getInstance().select(list,listItems);
 	}
 
 	public void select(int... indices) {
-		WidgetHandler.getInstance().select(list,indices);
+		ListHandler.getInstance().select(list,indices);
 	}
 	
 	public org.eclipse.swt.widgets.List getSWTWidget(){

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/scale/AbstractScale.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/scale/AbstractScale.java
@@ -20,7 +20,7 @@ public abstract class AbstractScale implements Scale {
 	 */
 	@Override
 	public int getMinimum() {
-		return ScaleHandler.getMinimum(this);
+		return ScaleHandler.getInstance().getMinimum(this.getSWTWidget());
 	}
 	/**
 	 * See {@link Scale}
@@ -28,21 +28,21 @@ public abstract class AbstractScale implements Scale {
 
 	@Override
 	public int getMaximum() {
-		return ScaleHandler.getMaximum(this);
+		return ScaleHandler.getInstance().getMaximum(this.getSWTWidget());
 	}
 	/**
 	 * See {@link Scale}
 	 */
 	@Override
 	public int getSelection() {
-		return ScaleHandler.getSelection(this);
+		return ScaleHandler.getInstance().getSelection(this.getSWTWidget());
 	}
 	/**
 	 * See {@link Scale}
 	 */
 	@Override
 	public void setSelection(int value) {
-		ScaleHandler.setSelection(this, value);		
+		ScaleHandler.getInstance().setSelection(this.getSWTWidget(), value);		
 	}
 	/**
 	 * See {@link Scale}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/spinner/AbstractSpinner.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/spinner/AbstractSpinner.java
@@ -1,6 +1,7 @@
 package org.jboss.reddeer.swt.impl.spinner;
 
 import org.jboss.reddeer.swt.api.Spinner;
+import org.jboss.reddeer.swt.handler.SpinnerHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 
 /**
@@ -15,12 +16,12 @@ public abstract class AbstractSpinner implements Spinner {
 
 	@Override
 	public int getValue() {
-		return WidgetHandler.getInstance().getValue(swtSpinner);
+		return SpinnerHandler.getInstance().getValue(swtSpinner);
 	}
 
 	@Override
 	public void setValue(int value) {
-		WidgetHandler.getInstance().setValue(swtSpinner, value);
+		SpinnerHandler.getInstance().setValue(swtSpinner, value);
 	}
 	
 	public org.eclipse.swt.widgets.Spinner getSWTWidget(){

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/table/AbstractTable.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/table/AbstractTable.java
@@ -56,7 +56,7 @@ public abstract class AbstractTable implements Table {
 	@Override
 	public List<TableItem> getItems(){
 		waitUntilTableHasRows();
-		org.eclipse.swt.widgets.TableItem[] items = (org.eclipse.swt.widgets.TableItem[])WidgetHandler.getInstance().getSWTItems(table);
+		org.eclipse.swt.widgets.TableItem[] items = TableHandler.getInstance().getSWTItems(table);
 		List<TableItem> tableItems = new ArrayList<TableItem>();
 		for(org.eclipse.swt.widgets.TableItem i: items){
 			tableItems.add(new BasicTableItem(i));
@@ -67,7 +67,7 @@ public abstract class AbstractTable implements Table {
 	@Override
 	public TableItem getItem(final int index) {
 		waitUntilTableHasRows();
-		org.eclipse.swt.widgets.TableItem tItem = (org.eclipse.swt.widgets.TableItem)WidgetHandler.getInstance().getSWTItem(table, index);
+		org.eclipse.swt.widgets.TableItem tItem = TableHandler.getInstance().getSWTItem(table, index);
 		return new BasicTableItem(tItem);
 	}
 	
@@ -75,7 +75,7 @@ public abstract class AbstractTable implements Table {
 	public TableItem getItem(final String itemText) {
 		waitUntilTableHasRows();
 		int row = TableHandler.getInstance().indexOf(table, itemText, 0);
-		org.eclipse.swt.widgets.TableItem tItem = (org.eclipse.swt.widgets.TableItem)WidgetHandler.getInstance().getSWTItem(table, row);
+		org.eclipse.swt.widgets.TableItem tItem = TableHandler.getInstance().getSWTItem(table, row);
 		return new BasicTableItem(tItem);
 	}
 	
@@ -83,7 +83,7 @@ public abstract class AbstractTable implements Table {
 	public TableItem getItem(final String itemText, int column) {
 		waitUntilTableHasRows();
 		int row = TableHandler.getInstance().indexOf(table, itemText, column);
-		org.eclipse.swt.widgets.TableItem tItem = (org.eclipse.swt.widgets.TableItem)WidgetHandler.getInstance().getSWTItem(table, row);
+		org.eclipse.swt.widgets.TableItem tItem = TableHandler.getInstance().getSWTItem(table, row);
 		return new BasicTableItem(tItem);
 	}
 
@@ -106,9 +106,9 @@ public abstract class AbstractTable implements Table {
 		}
 		waitUntilTableHasRows();
 		if(indexes.length == 1){
-			WidgetHandler.getInstance().select(table, indexes[0]);
+			TableHandler.getInstance().select(table, indexes[0]);
 		} else {
-			WidgetHandler.getInstance().select(table, indexes);
+			TableHandler.getInstance().select(table, indexes);
 		}
 		
 	}
@@ -126,13 +126,13 @@ public abstract class AbstractTable implements Table {
 	@Override
 	public void selectAll(){
 		waitUntilTableHasRows();
-		WidgetHandler.getInstance().selectAll(table);
+		TableHandler.getInstance().selectAll(table);
 	}
 
 	@Override
 	public void deselectAll() {
 		waitUntilTableHasRows();
-		WidgetHandler.getInstance().deselectAll(table);
+		TableHandler.getInstance().deselectAll(table);
 	}
 
 	private void waitUntilTableHasRows() {

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/table/AbstractTableItem.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/table/AbstractTableItem.java
@@ -7,6 +7,7 @@ import org.jboss.reddeer.swt.api.TableItem;
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.handler.TableHandler;
+import org.jboss.reddeer.swt.handler.TableItemHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 
 public class AbstractTableItem implements TableItem {
@@ -29,12 +30,12 @@ public class AbstractTableItem implements TableItem {
 	public void setChecked(final boolean check) {
 		log.info((check ? "Check" : "Uncheck") + "Table Item " + getText()
 				+ ":");
-		WidgetHandler.getInstance().setChecked(tableItem, check);
+		TableItemHandler.getInstance().setChecked(tableItem, check);
 	}
 
 	@Override
 	public boolean isChecked() {
-		return WidgetHandler.getInstance().isChecked(tableItem);
+		return TableItemHandler.getInstance().isChecked(tableItem);
 	}
 	
 	@Override
@@ -44,17 +45,17 @@ public class AbstractTableItem implements TableItem {
 	
 	@Override
 	public String getText(int cellIndex) {
-		return WidgetHandler.getInstance().getText(tableItem, cellIndex);
+		return TableItemHandler.getInstance().getText(tableItem, cellIndex);
 	}
 
 	@Override
 	public boolean isSelected() {
-		return WidgetHandler.getInstance().isSelected(tableItem);
+		return TableItemHandler.getInstance().isSelected(tableItem);
 	}
 
 	@Override
 	public void select() {
-		WidgetHandler.getInstance().select(tableItem);
+		TableItemHandler.getInstance().select(tableItem);
 	}
 	
 	@Override
@@ -69,7 +70,7 @@ public class AbstractTableItem implements TableItem {
 
 	@Override
 	public Table getParent() {
-		return (Table)WidgetHandler.getInstance().getParent(tableItem);
+		return new DefaultTable(TableItemHandler.getInstance().getParent(tableItem));
 	}
 	
 	@Override

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/table/DefaultTable.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/table/DefaultTable.java
@@ -43,4 +43,7 @@ public class DefaultTable extends AbstractTable implements Table {
 		super(WidgetLookup.getInstance().activeWidget(referencedComposite, org.eclipse.swt.widgets.Table.class, index));
 	}
 	
+	protected DefaultTable(org.eclipse.swt.widgets.Table table){
+		super(table);
+	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/text/AbstractText.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/text/AbstractText.java
@@ -2,9 +2,9 @@ package org.jboss.reddeer.swt.impl.text;
 
 import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.api.Text;
+import org.jboss.reddeer.swt.handler.TextHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.keyboard.KeyboardFactory;
-import org.jboss.reddeer.swt.lookup.WidgetLookup;
 
 /**
  * Abstract class for all Text implementations
@@ -19,7 +19,7 @@ public abstract class AbstractText implements Text {
 	@Override
 	public void setText(String str) {
 		log.info("Text set to: " + str);
-		WidgetHandler.getInstance().setText(w, str);
+		TextHandler.getInstance().setText(w, str);
 	}
 	
 	

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/toolbar/AbstractToolItem.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/toolbar/AbstractToolItem.java
@@ -2,6 +2,7 @@ package org.jboss.reddeer.swt.impl.toolbar;
 
 import org.jboss.reddeer.swt.api.ToolItem;
 import org.jboss.reddeer.swt.exception.Thrower;
+import org.jboss.reddeer.swt.handler.ToolItemHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 
 /**
@@ -18,8 +19,9 @@ public abstract class AbstractToolItem implements ToolItem {
 	@Override
 	public void click() {
 		Thrower.objectIsNull(toolItem, "ToolItem is null" );
-		WidgetHandler.getInstance().click(toolItem);
+		ToolItemHandler.getInstance().click(toolItem);
 	}
+	
 	/**
 	 * See {@link ToolItem}}
 	 */
@@ -34,7 +36,7 @@ public abstract class AbstractToolItem implements ToolItem {
 	 */
 	@Override
 	public boolean isSelected() {
-		return WidgetHandler.getInstance().isSelected(toolItem);
+		return ToolItemHandler.getInstance().isSelected(toolItem);
 	}
 	/**
 	 * See {@link ToolItem}}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/AbstractTreeItem.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/AbstractTreeItem.java
@@ -9,6 +9,7 @@ import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.condition.TreeItemHasMinChildren;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.handler.TreeHandler;
+import org.jboss.reddeer.swt.handler.TreeItemHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
@@ -58,7 +59,7 @@ public abstract class AbstractTreeItem implements TreeItem {
 	 */
 	@Override
 	public String getToolTipText() {
-		return WidgetHandler.getInstance().getToolTipText(swtTreeItem);
+		return TreeItemHandler.getInstance().getToolTipText(swtTreeItem);
 	}
 
 	/**
@@ -66,7 +67,7 @@ public abstract class AbstractTreeItem implements TreeItem {
 	 */
 	@Override
 	public String getCell(final int index) {
-		return WidgetHandler.getInstance().getText(swtTreeItem,index);
+		return TreeItemHandler.getInstance().getText(swtTreeItem,index);
 	}
 
 	/**

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/util/ObjectUtil.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/util/ObjectUtil.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 
 import org.eclipse.swt.widgets.Widget;
 
+
 /**
  * Object util contains helper methods for invoking methods by reflections, etc.
  * 
@@ -20,10 +21,21 @@ public class ObjectUtil {
 	 * @return returns result of the method invocation
 	 */
 	public static Object invokeMethod(final Object object, String methodName) {
+		return invokeMethod(object, methodName, new Class<?>[0], new Object[0]);
+	}
+	
+	/**
+	 * Invokes method by reflection, widget based method are executed in ui thread
+	 * 
+	 * @param object given instance
+	 * @param methodName method name to be invoked
+	 * @return returns result of the method invocation
+	 */
+	public static Object invokeMethod(final Object object, String methodName, final Class<?>[] argTypes, final Object[] args) {
 
 		final Method method;
 		try {
-			method = object.getClass().getMethod(methodName, new Class[0]);
+			method = object.getClass().getMethod(methodName, argTypes);
 		} catch (Exception e) {
 			throw new RuntimeException("Cannot get method : " + e.getMessage());
 		}
@@ -36,7 +48,7 @@ public class ObjectUtil {
 				public Object run() {
 					Object o = null;
 					try {
-						o = method.invoke(object, new Object[0]);
+						o = method.invoke(object, args);
 					} catch (Exception e) {
 						try {
 							throw new RuntimeException(
@@ -59,5 +71,4 @@ public class ObjectUtil {
 
 		return result;
 	}
-
 }

--- a/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/handler/HyperLinkHandler.java
+++ b/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/handler/HyperLinkHandler.java
@@ -1,0 +1,50 @@
+package org.jboss.reddeer.uiforms.handler;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.ui.forms.widgets.Hyperlink;
+import org.jboss.reddeer.swt.lookup.WidgetLookup;
+import org.jboss.reddeer.swt.util.Display;
+
+/**
+ * Contains methods that handle UI operations on {@link Hyperlink} widgets. 
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class HyperLinkHandler {
+
+	private static HyperLinkHandler instance;
+
+	private HyperLinkHandler() {
+
+	}
+
+	/**
+	 * Creates and returns instance of ComboHandler class
+	 * 
+	 * @return
+	 */
+	public static HyperLinkHandler getInstance() {
+		if (instance == null) {
+			instance = new HyperLinkHandler();
+		}
+		return instance;
+	}
+
+	/**
+	 * Activates widget - link/hyperlink etc
+	 * @param w widget to activate
+	 */
+	public void activate(final Hyperlink hyperLink) {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				hyperLink.setFocus();
+				WidgetLookup.getInstance().notifyHyperlink(SWT.MouseEnter, hyperLink);
+				WidgetLookup.getInstance().notifyHyperlink(SWT.MouseDown, hyperLink);
+				WidgetLookup.getInstance().notifyHyperlink(SWT.MouseUp, hyperLink);
+			}
+		});
+	}
+}

--- a/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/handler/SectionHandler.java
+++ b/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/handler/SectionHandler.java
@@ -2,10 +2,9 @@ package org.jboss.reddeer.uiforms.handler;
 
 import org.eclipse.ui.forms.widgets.Section;
 import org.jboss.reddeer.swt.util.Display;
-import org.jboss.reddeer.uiforms.section.UIFormSection;
 
 /**
- * Helper class for running methods on {@link UIFormSection} that require sync/async exec on UI thread. 
+ * Helper class for running methods on {@link Section} that require sync/async exec on UI thread. 
  * 
  * @author Lucia Jelinkova
  *

--- a/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/hyperlink/UIFormHyperlink.java
+++ b/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/hyperlink/UIFormHyperlink.java
@@ -4,6 +4,7 @@ import org.eclipse.ui.forms.widgets.Hyperlink;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.matcher.WithMnemonicMatcher;
 import org.jboss.reddeer.swt.reference.ReferencedComposite;
+import org.jboss.reddeer.uiforms.handler.HyperLinkHandler;
 import org.jboss.reddeer.uiforms.impl.hyperlink.DefaultHyperlink;
 import org.jboss.reddeer.uiforms.lookup.HyperlinkLookup;
 
@@ -109,7 +110,7 @@ public class UIFormHyperlink {
 	}
 	
 	public void activate() {
-		WidgetHandler.getInstance().activate(hyperLink);
+		HyperLinkHandler.getInstance().activate(hyperLink);
 	}
 
 	

--- a/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/impl/hyperlink/AbstractHyperlink.java
+++ b/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/impl/hyperlink/AbstractHyperlink.java
@@ -3,6 +3,7 @@ package org.jboss.reddeer.uiforms.impl.hyperlink;
 import org.eclipse.swt.widgets.Widget;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.uiforms.api.Hyperlink;
+import org.jboss.reddeer.uiforms.handler.HyperLinkHandler;
 
 /**
  * Common ancestor for all {@link Hyperlink} implementations
@@ -27,7 +28,7 @@ public abstract class AbstractHyperlink implements Hyperlink {
 	}
 	
 	public void activate() {
-		WidgetHandler.getInstance().activate(hyperLink);
+		HyperLinkHandler.getInstance().activate(hyperLink);
 	}
 	
 	protected void setFocus() {


### PR DESCRIPTION
WidgetHandler contains almost 1000 lines, most methods are specific to one or two widget type. Should they be moved to the appropriate handler (e. g. ButtonHandler)?
YES - mark as deprecated
