### PR TITLE
There is no way how to get whole text of Link widget.

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/api/Link.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/api/Link.java
@@ -1,25 +1,63 @@
 package org.jboss.reddeer.swt.api;
 
+import java.util.List;
+
 import org.jboss.reddeer.swt.widgets.Widget;
 
 /**
  * API For Link manipulation
- * @author Jiri Peterka
+ * 
+ * @author Jiri Peterka, rhopp
  *
  */
-public interface Link extends Widget{
-	
+public interface Link extends Widget {
+
 	/**
-	 * Returns text of link
+	 * Returns text of link stripped of &lt;a&gt; and &lt;/a&gt; tags.
+	 * <p/>
+	 * For example "This is a &lt;a&gt;link&lt;/a&gt;" will result in
+	 * "This is a link"
+	 * 
 	 * @return
 	 */
 	String getText();
-	
+
 	/**
-	 * Clicks on link
+	 * Return array of anchor texts (text between &lt;a&gt; and &lt;/a&gt;)
+	 * <p/>
+	 * For example "This is a &lt;a&gt;link&lt;/a&gt;" will result in "link"
+	 * 
+	 * @return list of texts between &lt;a&gt; and &lt;/a&gt;
+	 */
+
+	List<String> getAnchorTexts();
+
+	/**
+	 * Clicks on anchor with text within this link widget
+	 * 
+	 * Link widget can have multiple anchors in them. Example:
+	 * "Link &lt;a&gt;link1&lt;/a&gt; and &lt;A href="test"&gt;link2&lt;A\&gt;"
+	 * <p/>
+	 * 
+	 * link.click(link1) envokes SWT.Selection event with "link1" as event's
+	 * text.
+	 * <p/>
+	 * link.click(link2) envokes SWT.Selection event with "test" as event's
+	 * text.
+	 * 
+	 */
+	void click(String text);
+
+	/**
+	 * Clicks on first anchor of this link widget.
 	 */
 	void click();
-	
+
+	/**
+	 * Clicks on the nth anchor of this link widget.
+	 */
+	void click(int index);
+
 	org.eclipse.swt.widgets.Link getSWTWidget();
 
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/LinkHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/LinkHandler.java
@@ -1,14 +1,22 @@
 package org.jboss.reddeer.swt.handler;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Link;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
 /**
- * Contains methods that handle UI operations on {@link Link} widgets. 
+ * Contains methods that handle UI operations on {@link Link} widgets.
  * 
- * @author Lucia Jelinkova
+ * @author Lucia Jelinkova, rhopp
  *
  */
 public class LinkHandler {
@@ -31,34 +39,178 @@ public class LinkHandler {
 		return instance;
 	}
 
-	public String getText(final Link l){
+	/**
+	 * This method parses given link text for containing anchors, then returns
+	 * those anchor's texts as list of strings
+	 * <p/>
+	 * For example
+	 * "This is a &lt;a&gt;link1&lt;/a&gt; and &lt;a&gt;link2&lt;/a&gt;" will
+	 * result in ["link1","link2"]
+	 * 
+	 * @param l
+	 * @return
+	 */
+	public List<String> getAnchorTexts(final Link l) {
 
-		String linkText = Display.syncExec(new ResultRunnable<String>() {
-			@Override
-			public String run() {
-				return l.getText();
-			}
-		});
-
-		String[] split1 = linkText.split(".*<[aA]>");
-		String[] split2 = split1[split1.length-1].split("</[aA]>.*");
-		return split2[0];
+		String linkText = getTextInternal(l);
+		List<String> anchorTextList = new ArrayList<String>();
+		for (AnchorPair anchorPair : parseLinks(linkText)) {
+			anchorTextList.add(anchorPair.getAnchorText());
+		}
+		return anchorTextList;
 	}
 
 	/**
-	 * Activates widget - link/hyperlink etc
-	 * @param w widget to activate
+	 * This method returns text, which should be passed as event.text in
+	 * selection event, for anchor in given link, specified by its text and
+	 * index.
+	 * 
+	 * @param l
+	 *            given link
+	 * @param text
+	 *            text of the anchor (text between &lt;a&gt; and &lt;/a&gt;)
+	 * @param index
+	 *            index of anchor, given that multiple anchors have same text
+	 * @return
 	 */
-	public void activate(final Link link) {
+	public String getEventText(final Link l, String text, int index) {
+		String linkText = getTextInternal(l);
+		int counter = 0;
+		for (AnchorPair ap : parseLinks(linkText)) {
+			if (ap.getAnchorText().equals(text)) {
+				if (counter != index) {
+					counter++;
+				} else {
+					return ap.getAnchorHref().equals("") ? ap.getAnchorText()
+							: ap.getAnchorHref();
+				}
+			}
+		}
+		throw new SWTLayerException("There is no anchor with text [" + text
+				+ "] and index " + index + " in this link");
+	}
+
+	/**
+	 * This method returns text, which should be passed as event.text in
+	 * selection event, for anchor in given link, specified by its index.
+	 * 
+	 * @param l
+	 *            given link
+	 * @param index
+	 *            index of anchod within given link
+	 * @return
+	 */
+	public String getEventText(final Link l, int index) {
+		String linkText = getTextInternal(l);
+		List<AnchorPair> list = parseLinks(linkText);
+		Collections.sort(list);
+		AnchorPair ap = null;
+		try {
+			ap = list.get(index);
+		} catch (IndexOutOfBoundsException ex) {
+			throw new SWTLayerException("There are only " + list.size()
+					+ " anchors in this link and you requested anchor #"
+					+ index);
+		}
+		return ap.getAnchorHref().equals("") ? ap.getAnchorText() : ap
+				.getAnchorHref();
+	}
+
+	/**
+	 * This method strips given link's text of anchor tags.
+	 * <p/>
+	 * For link with text "This is a &lt;a&gt;link&lt;/a&gt;" this method will
+	 * return "This is a link"
+	 * 
+	 * @param l given link
+	 * @return
+	 */
+
+	public String getText(final Link l) {
+		return getTextInternal(l).replaceAll("<[aA]([^>]*)>(.+?)</[aA]>", "$2");
+	}
+	
+	/**
+	 * Activates widget - link/hyperlink etc
+	 * 
+	 * @param w
+	 *            widget to activate
+	 */
+	public void activate(final Link link, final String text) {
 		Display.syncExec(new Runnable() {
 
 			@Override
 			public void run() {
 				link.setFocus();
 				WidgetHandler.getInstance().notify(SWT.MouseDown, link);
-				WidgetHandler.getInstance().notify(SWT.Selection, link);
+				notifySelection(link, text);
 				WidgetHandler.getInstance().notify(SWT.MouseUp, link);
 			}
 		});
 	}
+
+	private List<AnchorPair> parseLinks(String linkText) {
+		List<AnchorPair> list = new ArrayList<AnchorPair>();
+		Pattern p = Pattern.compile("<[aA]([^>]*)>(.+?)</[aA]>");
+		Matcher m = p.matcher(linkText);
+		int counter = 0;
+		while (m.find()) {
+			list.add(new AnchorPair(counter, m.group(2), parseHref(m.group(1))));
+			counter++;
+		}
+		return list;
+	}
+
+	private String parseHref(String text) {
+		return text.replaceAll(".*href=\"([^\"]*).*", "$1");
+	}
+
+	private String getTextInternal(final Link l) {
+		String text = Display.syncExec(new ResultRunnable<String>() {
+			@Override
+			public String run() {
+				return l.getText();
+			}
+		});
+		return text;
+	}
+
+	private void notifySelection(Link link, String text) {
+		Event event = new Event();
+		event.time = (int) System.currentTimeMillis();
+		event.widget = link;
+		event.display = Display.getDisplay();
+		event.text = text;
+		event.type = SWT.Selection;
+		link.notifyListeners(event.type, event);
+	}
+
+	private class AnchorPair implements Comparable<AnchorPair> {
+		private int index;
+		private String anchorText;
+		private String anchorHref;
+
+		public AnchorPair(int index, String anchorText, String anchorHref) {
+			this.anchorHref = anchorHref;
+			this.anchorText = anchorText;
+		}
+
+		public int getIndex() {
+			return index;
+		}
+
+		public String getAnchorHref() {
+			return anchorHref;
+		}
+
+		public String getAnchorText() {
+			return anchorText;
+		}
+
+		@Override
+		public int compareTo(AnchorPair o) {
+			return o.getIndex() - index;
+		}
+	}
+
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/link/AbstractLink.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/link/AbstractLink.java
@@ -1,28 +1,49 @@
 package org.jboss.reddeer.swt.impl.link;
 
+import java.util.List;
+
 import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.api.Link;
 import org.jboss.reddeer.swt.handler.LinkHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 
-public abstract class AbstractLink implements Link{
-	
+public abstract class AbstractLink implements Link {
+
 	protected org.eclipse.swt.widgets.Link link;
 
 	protected final Logger logger = Logger.getLogger(this.getClass());
-	
-	public String getText(){
+
+	public String getText() {
 		return LinkHandler.getInstance().getText(link);
 	}
-	
-	public void click(){
-		LinkHandler.getInstance().activate(link);
+
+	public List<String> getAnchorTexts() {
+		return LinkHandler.getInstance().getAnchorTexts(link);
 	}
-	
-	public org.eclipse.swt.widgets.Link getSWTWidget(){
+
+	public void click(String text) {
+		click(text, 0);
+	}
+
+	public void click(String text, int index) {
+		String eventText = LinkHandler.getInstance().getEventText(link, text,
+				index);
+		LinkHandler.getInstance().activate(link, eventText);
+	}
+
+	public void click() {
+		click(0);
+	}
+
+	public void click(int index) {
+		String eventText = LinkHandler.getInstance().getEventText(link, index);
+		LinkHandler.getInstance().activate(link, eventText);
+	}
+
+	public org.eclipse.swt.widgets.Link getSWTWidget() {
 		return link;
 	}
-	
+
 	@Override
 	public boolean isEnabled() {
 		return WidgetHandler.getInstance().isEnabled(link);

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/button/LinkTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/button/LinkTest.java
@@ -64,7 +64,7 @@ public class LinkTest extends RedDeerTest{
 		new DefaultShell("Shell with link");
 		org.jboss.reddeer.swt.api.Link l = new org.jboss.reddeer.swt.impl.link.DefaultLink("shell");
 		assertEquals("shell",l.getText());
-		l.click();
+		l.click("shell");
 		assertEquals("Shell opened by link",new DefaultShell().getText());
 	}
 

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/link/DefaultLinkTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/link/DefaultLinkTest.java
@@ -1,0 +1,170 @@
+package org.jboss.reddeer.swt.test.impl.link;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.impl.link.DefaultLink;
+import org.jboss.reddeer.swt.impl.text.DefaultText;
+import org.jboss.reddeer.swt.test.RedDeerTest;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.wait.WaitWhile;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultLinkTest extends RedDeerTest {
+	
+	@Before
+	public void setup(){
+		super.setUp();
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				Shell shell = new Shell(org.eclipse.swt.widgets.Display.getDefault());
+				shell.setText("Testing shell");
+				createControls(shell);
+				shell.open();
+				shell.setFocus();
+			}
+		});
+	}
+	
+	@After
+	public void cleanup() {
+		Display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				for (Shell shell : org.jboss.reddeer.swt.
+						util.Display.getDisplay().getShells()) {
+					if (shell.getText().equals("Testing shell")) {
+						shell.dispose();
+						break;
+					}
+				}
+			}
+		});
+		new WaitWhile(new ShellWithTextIsActive("Testing shell"));
+	}
+	
+	private void createControls(Shell parent){
+		final Text text = new Text(parent, SWT.BORDER);
+		text.setSize(100,30);
+		text.setLocation(100,50);
+		text.setText("");
+		Link link1 = new Link(parent, SWT.BORDER);
+		link1.setSize(100, 30);
+		link1.setLocation(100, 100);
+		link1.setText("This is a <a href=\"test1\">link1</a>");
+		link1.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				text.setText(e.text);
+			}
+
+		});
+		Link link2 = new Link(parent, SWT.BORDER);
+		link2.setSize(100, 30);
+		link2.setLocation(100, 150);
+		link2.setText("This is another <A>link2</A> with two <a href=\"test2\">links</a>");
+		link2.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				text.setText(e.text);
+			}
+
+		});
+		Link link3 = new Link(parent, SWT.BORDER);
+		link3.setSize(100, 30);
+		link3.setLocation(100,200);
+		link3.setText("Link with same texts <a href=\"same1\">same</a><a href=\"same2\">same</a>");
+		link3.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				text.setText(e.text);
+			}
+
+		});
+	}
+	
+	
+	@Test
+	public void stringConstructorTest(){
+		org.jboss.reddeer.swt.api.Link link1 = new DefaultLink("This is a link1");
+		org.jboss.reddeer.swt.api.Link link2 = new DefaultLink("This is another link2 with two links");
+		assertNotNull(link1);
+		assertNotNull(link2);
+	}
+	
+	@Test
+	public void getTextTest(){
+		String text1 = new DefaultLink().getText();
+		String text2 = new DefaultLink(1).getText();
+		assertEquals("This is a link1", text1);
+		assertEquals("This is another link2 with two links", text2);
+	}
+	
+	@Test
+	public void getHrefTextsTest(){
+		List<String> text1 = new DefaultLink().getAnchorTexts();
+		List<String> text2 = new DefaultLink(1).getAnchorTexts();
+		assertEquals(1, text1.size());
+		assertEquals(2, text2.size());
+		assertEquals("link1", text1.get(0));
+		assertEquals("link2", text2.get(0));
+		assertEquals("links", text2.get(1));
+	}
+	
+	@Test
+	public void clickTest(){
+		org.jboss.reddeer.swt.api.Text text = new DefaultText(0);
+		assertEquals("", text.getText());
+		new DefaultLink().click("link1");
+		assertEquals("test1", text.getText());
+		new DefaultLink(1).click("link2");
+		assertEquals("link2", text.getText());
+		new DefaultLink(1).click("links");
+		assertEquals("test2", text.getText());
+		new DefaultLink().click();
+		assertEquals("test1", text.getText());
+		new DefaultLink(1).click();
+		assertEquals("link2", text.getText());
+		new DefaultLink(1).click(1);
+		assertEquals("test2", text.getText());
+	}
+	
+	@Test(expected=SWTLayerException.class)
+	public void clickWrongTextTest(){
+		new DefaultLink().click("wrongText");
+	}
+	
+	@Test(expected=SWTLayerException.class)
+	public void clickWrongIndexTest(){
+		new DefaultLink().click(1);
+	}
+	
+	@Test
+	public void sameAnchorTextTest(){
+		org.jboss.reddeer.swt.api.Text text = new DefaultText(0);
+		DefaultLink link = new DefaultLink(2);
+		link.click("same", 0);
+		assertEquals("same1", text.getText());
+		link.click("same", 1);
+		assertEquals("same2", text.getText());
+	}
+
+}


### PR DESCRIPTION
Currently, getText() method returns just text between <a></a> tags (as implemented in WidgetHandler.getText()). 
Naming such method getText() could be IMHO misleading as it is not returning whole text. 
I suggest to change behaviour of this method to return whole text and create another method to return just link between <a></a>. 
WDYT?
