### PR TITLE
Review and update missing javadoc for org.jboss.reddeer.direct plugin

### DIFF
--- a/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/Activator.java
+++ b/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/Activator.java
@@ -4,7 +4,9 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
 /**
- * The activator class controls the plug-in life cycle
+ * Org.jboss.reddeer.direct plugin activator. Bundle reserved for direct
+ * operations (direct eclipse and non-eclipse API calls without UI interaction)
+ * The activator class controls the plug-in life cycle.
  */
 public class Activator extends AbstractUIPlugin {
 

--- a/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/platform/OS.java
+++ b/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/platform/OS.java
@@ -1,8 +1,8 @@
 package org.jboss.reddeer.direct.platform;
 /**
- * Constants for running OS
+ * Constants for running OS containing main operation system families
  * @author Vlado Pakan
- *
+ * @since 0.5
  */
 public enum OS {
 	WINDOWS,LINUX,MACOSX

--- a/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/platform/RunningPlatform.java
+++ b/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/platform/RunningPlatform.java
@@ -6,53 +6,55 @@ import org.eclipse.core.runtime.Platform;
  * Running platforms provides information about currently running instance
  * like Operation System, etc.
  * @author Jiri Peterka
- *
+ * @since 0.5
  */
 public class RunningPlatform {
 	
-	private static final String OS_NAME = Platform.getOS().toLowerCase();
+	private static final String CURRENT_OS = Platform.getOS().toLowerCase();
 
 	/**
-	 * Returns true when machine operating system is os
-	 * @param expected os 
-	 * @return returns true if given OS matches with running OS
+	 * Checks if Operating system family belongs to given OS family
+	 * @param os given os to check with  
+	 * @return returns true if given os matches with running operation system
 	 */
 	public static boolean isOperationSystem(OS os){
 		
 		boolean result = false;
 		
 		if (os.equals(OS.WINDOWS)){
-			result = OS_NAME.startsWith("win");
+			result = isWindows();
 		} 
 		else if (os.equals(OS.MACOSX)){
-			result = OS_NAME.startsWith("macosx");
+			result = isOSX();
 		}else if (os.equals(OS.LINUX)){
-			result = !(OS_NAME.startsWith("macosx") 
-					|| OS_NAME.startsWith("win"));
+			result = !(isOSX() || isWindows()); 
 		}
 		
 		return result;
 	}
 	
 	/**
+	 * Checks if current system belongs To Windows OS family 
 	 * @return true if running platform is Windows
 	 */
 	public static boolean isWindows() {
-		return OS_NAME.startsWith("win");
+		return CURRENT_OS.startsWith("win");
 	}
 
 	/**
+	 * Checks if current system belongs to Apple OSX family
 	 * @return true if running platform is OSX
 	 */	
 	public static boolean isOSX() {
-		return OS_NAME.startsWith("macosx");
+		return CURRENT_OS.startsWith("macosx");
 	}
 
 	/**
+	 * Checks if current system belongs to GNU/Linux operation system family
 	 * @return true if running platform is Linux
 	 */		
 	public static boolean isLinux() {
-		return OS_NAME.startsWith("linux");
+		return CURRENT_OS.startsWith("linux");
 	}
 
 }


### PR DESCRIPTION
Review and update missing javadoc
- all public members (classes, methods, etc.) should contains javadoc
- user should be able able to understand behaviour from description without analyzing the code
- use since (for example since 0.5 means <0.5-snapshot...0.6)
- use deprecated with referencing the replacement
