### PR TITLE
Add logic to check that for each required server there is a corresponding server config

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
@@ -21,6 +21,8 @@ import org.junit.runners.model.RunnerBuilder;
  */
 public class RequirementsRunnerBuilder extends RunnerBuilder {
 
+	public TestsExecutionManager testsManager;
+
 	private Logger log = Logger.getLogger(RequirementsRunnerBuilder.class);
 	
 	private RequirementsBuilder requirementsBuilder = new RequirementsBuilder();
@@ -33,26 +35,33 @@ public class RequirementsRunnerBuilder extends RunnerBuilder {
 	private RunListener[] runListeners;
 	
 	public RequirementsRunnerBuilder(TestRunConfiguration config) {
-		this(config,null,null);
+		this(config, null, null, null, null);
 	}
 	
 	public RequirementsRunnerBuilder(TestRunConfiguration config , RunListener[] runListeners , List<IBeforeTest> beforeTestExtensions) {
-		this(config, runListeners, beforeTestExtensions, null);
+		this(config, runListeners, beforeTestExtensions, null, null);
 	}
 	
-	public RequirementsRunnerBuilder(TestRunConfiguration config , RunListener[] runListeners , List<IBeforeTest> beforeTestExtensions, List<IAfterTest> afterTestExtensions) {
+	public RequirementsRunnerBuilder(TestRunConfiguration config , RunListener[] runListeners , List<IBeforeTest> beforeTestExtensions, List<IAfterTest> afterTestExtensions, TestsExecutionManager testsManager) {
 		this.config = config;
 		this.runListeners = runListeners;
 		this.beforeTestExtensions = beforeTestExtensions;
 		this.afterTestExtensions = afterTestExtensions;
+		this.testsManager = testsManager;
 	}
 
 	@Override
 	public Runner runnerForClass(Class<?> clazz) throws Throwable {
 		log.info("Found test " + clazz);
+		if(testsManager != null) {
+			testsManager.addTest(clazz);
+		}
 		Requirements requirements = requirementsBuilder.build(clazz, config.getRequirementConfiguration());
 		if (requirements.canFulfill()){
 			log.info("All requirements can be fulfilled, the test will run");
+			if(testsManager != null) {
+				testsManager.addExecutedTest(clazz);
+			}
 			return new RequirementsRunner(clazz, requirements, config.getId(),runListeners, beforeTestExtensions, afterTestExtensions);
 		} else {
 			log.info("All requirements cannot be fulfilled, the test will NOT run");

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/TestWithoutExecutionRunner.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/TestWithoutExecutionRunner.java
@@ -1,0 +1,54 @@
+package org.jboss.reddeer.junit.internal.runner;
+
+import java.util.List;
+
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * Special runner invoking {@link InitializationError}
+ * for each test class.<br/>
+ * 
+ * It doesn't run tests, it just provide information about tests
+ * in error's message.
+ * 
+ * @author Radoslav Rabara
+ *
+ */
+public class TestWithoutExecutionRunner extends BlockJUnit4ClassRunner {
+
+	/**
+	 * Constructs {@link Runner}, which invokes {@link InitializationError}
+	 * for each test class. Error has message that the specified {@link Class}
+	 * was not executed because the requirements was not fulfilled
+	 * for a single configuration file 
+	 * 
+	 * @param klass
+	 * @throws InitializationError
+	 */
+	public TestWithoutExecutionRunner(Class<?> klass) throws InitializationError {
+		super(klass);
+	}
+	
+	@Override
+	protected String testName(FrameworkMethod method) {
+		return method.getName()
+				+ " - without a single run (requirements was not fulfilled)";
+	}
+	
+	@Override
+	protected void collectInitializationErrors(List<Throwable> errors) {
+		errors.add(new TestHasNoRunError());//tests will fails with initialization error
+	}
+	
+	private static class TestHasNoRunError extends InitializationError {
+		public TestHasNoRunError() {
+			super("Test has no run"
+					+ "(requirements was not fulfilled for a single test configuration)");
+		}
+	}
+}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/TestsExecutionManager.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/TestsExecutionManager.java
@@ -1,0 +1,79 @@
+package org.jboss.reddeer.junit.internal.runner;
+
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Divides test classes into two categories:
+ * <ul>
+ * <li>Test classes <b>with</b> a run</li>
+ * <li>Test classes <b>without</b> a run</li>
+ * </ul>
+ * 
+ * Usage:<br/>
+ * Add test class to {@link TestsExecutionManager} using method {@link #addTest(Class)}.
+ * It will be added as test without a run.<br/><br/>
+ * 
+ * If the test class has a run, change the state of the test class
+ * using method {@link #addExecutedTest(Class)}.
+ * 
+ * @author Radoslav Rabara
+ *
+ */
+public class TestsExecutionManager {
+		
+	private Set<Class<?>> allTestClasses = new TreeSet<Class<?>>(classNameComparator);
+	private Set<Class<?>> executedTestClasses = new TreeSet<Class<?>>(classNameComparator);
+	
+	private static Comparator<Class<?>> classNameComparator = new Comparator<Class<?>>(){
+		@Override
+		public int compare(Class<?> clazz0, Class<?> clazz1) {
+			return clazz0.getName().compareTo(clazz1.getName());
+		}
+	};
+	
+	/**
+	 * Adds the specified <var>testClass</var> to the manager
+	 * as test class WITHOUT A RUN
+	 * 
+	 * @param testClass test {@link Class} to be added
+	 * 				as test class without a run
+	 */
+	public void addTest(Class<?> testClass) {
+		allTestClasses.add(testClass);
+	}
+	
+	/**
+	 * Adds the specified <var>testClass</var> to the manager
+	 * as test class WITH A RUN
+	 * 
+	 * @param testClass test {@link Class} to be added
+	 * 				as test class with a run
+	 */
+	public void addExecutedTest(Class<?> testClass) {
+		addTest(testClass);
+		executedTestClasses.add(testClass);
+	}
+	
+	/**
+	 * Calculates the number of tests without a run
+	 * 
+	 * @return the number of tests without a run
+	 */
+	public boolean allTestsAreExecuted() {
+		int notExecutedTestsCount = allTestClasses.size() - executedTestClasses.size();
+		return notExecutedTestsCount == 0;
+	}
+	
+	/**
+	 * Returns <code>true</code> if the specified test {@link Class}
+	 * has a run
+	 * 
+	 * @param testClass test {@link Class} whose status is to be tested 
+	 * @return <code>true</code> if the specified test class has a run
+	 */
+	public boolean isExecuted(Class<?> testClass) {
+		return executedTestClasses.contains(testClass); 
+	}
+}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/TestsWithoutExecutionSuite.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/TestsWithoutExecutionSuite.java
@@ -1,0 +1,73 @@
+package org.jboss.reddeer.junit.internal.runner;
+
+import org.junit.runner.Runner;
+import org.junit.runners.Suite;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
+
+/**
+ * Suite containing tests without a run.<br/>
+ * <br/>
+ * 
+ * It doesn't execute tests. The suite only informs that there are tests, whose
+ * requirements were not fulfilled for any test configuration
+ * so the tests were not executed at all.<br/>
+ * 
+ * @author Radoslav Rabara
+ *
+ */
+public class TestsWithoutExecutionSuite extends Suite {
+
+	/**
+	 * Constructs {@link Suite} informing about tests, which were not
+	 * executed even once.
+	 * 
+	 * @param clazz test class or test suite containing test classes
+	 * @param testsManager {@link TestsExecutionManager} used to determine
+	 * 						if the test classes were executed or not
+	 * @throws InitializationError is thrown when the initialization fails
+	 */
+	public TestsWithoutExecutionSuite(Class<?> clazz, TestsExecutionManager testsManager)
+			throws InitializationError {
+		super(clazz, new TestsWithoutRunRunnerBuilder(testsManager));
+	}
+	
+	/**
+	 * Constructor used for separate independent classes. 
+	 * 
+	 * @see #TestsWithoutExecutionSuite(Class, TestsExecutionManager)
+	 */
+	public TestsWithoutExecutionSuite(Class<?>[] classes, TestsExecutionManager testsManager) throws InitializationError {
+		super(new TestsWithoutRunRunnerBuilder(testsManager), EmptySuite.class, classes);
+	}
+	
+	
+	@Override
+	public String getName() {
+		return "NOT EXECUTED TESTS";
+	}
+
+	@Override
+	public String toString() {
+		return "Suite '" + this.getClass().getName() + "' "
+				+ "showing tests without a single run";
+	}
+
+	private static class TestsWithoutRunRunnerBuilder extends RunnerBuilder {
+
+		private TestsExecutionManager testsRunManager;
+
+		public TestsWithoutRunRunnerBuilder(TestsExecutionManager testsManager) {
+			this.testsRunManager = testsManager;
+		}
+
+		@Override
+		public Runner runnerForClass(Class<?> clazz) throws Throwable {
+			if (testsRunManager.isExecuted(clazz)) {
+				return null;
+			}
+			return new TestWithoutExecutionRunner(clazz);
+		}
+
+	}
+}

--- a/tests/org.jboss.reddeer.junit.test/src/test/java/org/jboss/reddeer/junit/runner/UnfulfillableRequirement.java
+++ b/tests/org.jboss.reddeer.junit.test/src/test/java/org/jboss/reddeer/junit/runner/UnfulfillableRequirement.java
@@ -1,0 +1,31 @@
+package org.jboss.reddeer.junit.runner;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jboss.reddeer.junit.requirement.Requirement;
+
+public class UnfulfillableRequirement implements Requirement<Annotation> {
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	@interface Unfulfillable {
+		
+	}
+	
+	public boolean canFulfill() {
+		return false;
+	}
+	
+	public void fulfill() {
+
+	}
+
+	@Override
+	public void setDeclaration(Annotation declaration) {
+		
+	}
+}


### PR DESCRIPTION
AFAIK, currently when you have a test in your testsuite that requires a server that is not configured, this test will simply be skipped. It is desirable that in such case this test fails and you will see the failure in the report.
