### PR TITLE
Add Build (Jenkins server) view to support for Mylyn tests for Hudson/Jenkins Connector

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/MylynBuild.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/MylynBuild.java
@@ -1,0 +1,70 @@
+package org.jboss.reddeer.eclipse.mylyn.tasks.ui.view;
+
+import org.jboss.reddeer.junit.logging.Logger;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.condition.JobIsRunning;
+import org.jboss.reddeer.swt.condition.WaitCondition;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.menu.ContextMenu;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.jboss.reddeer.swt.wait.WaitUntil;
+import org.jboss.reddeer.swt.wait.WaitWhile;
+
+	/**
+	 * Represents a TaskList on {@link TaskListView}. 
+	 * 
+	 * @author ldimaggi
+	 * 
+	 */
+	public class MylynBuild {
+
+		private static final TimePeriod TIMEOUT = TimePeriod.VERY_LONG;
+		
+		protected final Logger log = Logger.getLogger(this.getClass());
+		
+		private TreeItem treeItem;
+
+		public MylynBuild(TreeItem treeItem) {
+			this.treeItem = treeItem;
+		}
+
+		public void delete() {
+			delete(false);
+		}
+
+		public void delete(boolean stopFirst) {
+			log.info("Deleting Build");
+			select();
+			new ContextMenu("Delete").select();	
+			new PushButton("OK").click();
+			new WaitUntil(new TreeItemIsDisposed(treeItem), TIMEOUT);
+			new WaitWhile(new JobIsRunning(), TIMEOUT);
+		}
+
+		protected void select() {
+			treeItem.select();
+		}
+
+		public String getName(){
+			return treeItem.getText();
+		}
+
+		private class TreeItemIsDisposed implements WaitCondition {
+
+			private TreeItem treeItem;
+
+			public TreeItemIsDisposed(TreeItem treeItem) {
+				this.treeItem = treeItem;
+			}
+
+			@Override
+			public boolean test() {
+				return treeItem.isDisposed();
+			}
+
+			@Override
+			public String description() {
+				return "Build tree item is disposed";
+			}
+		}
+	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/MylynBuildView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/MylynBuildView.java
@@ -1,0 +1,92 @@
+package org.jboss.reddeer.eclipse.mylyn.tasks.ui.view;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
+import org.jboss.reddeer.swt.api.Tree;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.impl.tree.DefaultTree;
+import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.jboss.reddeer.swt.wait.WaitUntil;
+import org.jboss.reddeer.workbench.view.View;
+import org.jboss.reddeer.swt.condition.TreeItemHasMinChildren;
+import org.jboss.reddeer.swt.impl.link.DefaultLink;
+import org.jboss.reddeer.swt.impl.text.DefaultText;
+import org.jboss.reddeer.swt.impl.text.LabeledText;
+import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
+
+/**
+ * Represents the Build List view - to support Mylyn automated tests. 
+ *  
+ * @author ldimaggi
+ *
+ */
+public class MylynBuildView extends View {
+	
+	public static final String TITLE = "Builds";
+	
+	public MylynBuildView() {
+		super(TITLE);
+	}
+
+	public List<MylynBuild> getMylynBuilds(){
+		List<MylynBuild> theMylynBuilds = new ArrayList<MylynBuild>();
+
+		Tree tree;
+		try {
+			tree = new DefaultTree();
+		} catch (SWTLayerException e){
+			return new ArrayList<MylynBuild>();
+		}
+		for (TreeItem item : tree.getItems()){
+			theMylynBuilds.add(new MylynBuild(item));
+		}
+		return theMylynBuilds;
+	}
+
+	public MylynBuild getMylynBuild(String name){
+		for (MylynBuild repository : getMylynBuilds()){
+			if (repository.getName().equals(name)){
+				return repository;
+			}
+		}
+		throw new EclipseLayerException("There is no build with name " + name);
+	}
+
+	protected Tree getBuildsTree(){
+		open();
+		return new DefaultTree();
+	}
+	
+	/* Method to locate and select a build in the build list view  */
+	public TreeItem getBuild (String buildName) {
+		new DefaultTree();
+		DefaultTreeItem theBuild = new DefaultTreeItem (buildName);
+		theBuild.select();
+		return theBuild;
+	}
+	
+	/* For use in the Build List View */
+	public void createBuildServer (String serverURL) {
+		log.info("Creating New Build Server - " + serverURL);
+		new DefaultToolItem("New Build Server Location").click();
+		
+		new DefaultShell ("New Repository");
+		new DefaultTreeItem ("Hudson (supports Jenkins)").select();
+		new PushButton("Next >").click();
+		
+		new DefaultShell ("New Build Server");
+		new LabeledText ("Server:").setText(serverURL);
+		new LabeledText ("Label:").setText(serverURL);
+		new PushButton("Finish").click();
+	}
+	
+}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/BuildServerDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/BuildServerDialog.java
@@ -1,0 +1,75 @@
+package org.jboss.reddeer.eclipse.ui.ide;
+
+import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.wait.AbstractWait;
+import org.jboss.reddeer.swt.wait.WaitWhile;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+
+/**
+ * Represents Build Server dialog
+ * 
+ * @author ldimaggi
+ *
+ */
+public class BuildServerDialog extends DefaultShell {
+
+	public static final String TITLE = "Build Server Properties";
+	
+	/**
+	 * Open QuickFix dialog and set focus on it
+	 */
+	public BuildServerDialog() {
+		super(TITLE);
+	}
+	
+	/**
+	 * Press Select All button
+	 */
+	public void selectAll() {
+		new PushButton("Select All").click();
+	}
+	
+	/**
+	 * Press Deselect All button
+	 */
+	public void deselectAll() {
+		new PushButton("Deselect All").click();
+	}
+	
+        /**
+	 * Press Refresh button
+        */
+        public void refresh() {
+                new PushButton("Refresh").click();
+        }
+
+	/**
+	 * Press Cancel button
+	 */
+	public void cancel() {
+		new PushButton("Cancel").click();
+		new WaitWhile(new ShellWithTextIsActive(TITLE));
+	}
+	
+	/**
+	 * Press Finish button
+	 */
+	public void finish() {
+		new PushButton("Finish").click();
+		new WaitWhile(new ShellWithTextIsActive(TITLE));
+	}
+	
+	/**
+	 * Press Validate button
+	 */
+	public void validateSettings() {
+		PushButton validate = new PushButton("Validate");
+		validate.click();
+		while (!validate.isEnabled()) {
+			AbstractWait.sleep(TimePeriod.NORMAL.getSeconds());
+		}
+	}
+	
+}

--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -81,6 +81,12 @@
                             <artifactId>org.eclipse.mylyn.bugzilla_feature.feature.group</artifactId>
                             <version>0.0.0</version>
                         </dependency>
+			<dependency>
+				<type>p2-installable-unit</type>
+				<artifactId>org.eclipse.mylyn.hudson.feature.group</artifactId>
+				<version>0.0.0</version>
+			</dependency>
+
 					</dependencies>
 				</configuration>
 			</plugin>

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/view/MylynBuildViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/view/MylynBuildViewTest.java
@@ -1,0 +1,33 @@
+package org.jboss.reddeer.eclipse.test.mylyn.tasks.ui.view;
+
+import org.jboss.reddeer.eclipse.mylyn.tasks.ui.view.MylynBuildView;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.jboss.reddeer.swt.test.RedDeerTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 
+ * @author ldimaggi
+ *
+ */
+public class MylynBuildViewTest extends RedDeerTest {
+	/* Cannot use machydra Jenkins server due to - https://issues.jboss.org/browse/JBDS-2965 */
+	protected final String SERVERURL = "https://hudson.jboss.org/hudson/";
+
+	@Test
+	public void getBuildTest() {
+		
+		MylynBuildView listView = new MylynBuildView();	
+		listView.open();
+		listView.createBuildServer(SERVERURL);	
+		listView.open();
+				
+		TreeItem retBuild = (DefaultTreeItem)listView.getBuild (SERVERURL);
+		assertTrue ("Build was found", (retBuild.getText().equals(SERVERURL)));
+	}	
+}
+
+

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/ide/BuildServerDialogTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/ide/BuildServerDialogTest.java
@@ -1,0 +1,87 @@
+package org.jboss.reddeer.eclipse.test.ui.ide;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.reddeer.eclipse.ui.ide.BuildServerDialog;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.impl.text.LabeledText;
+import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
+import org.jboss.reddeer.swt.impl.tree.DefaultTree;
+import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.jboss.reddeer.swt.test.RedDeerTest;
+import org.jboss.reddeer.swt.wait.AbstractWait;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 
+ * @author ldimaggi
+ * 
+ */
+public class BuildServerDialogTest extends RedDeerTest {
+
+	/* Cannot use machydra Jenkins server due to - https://issues.jboss.org/browse/JBDS-2965 */
+	protected final String SERVERURL = "https://hudson.jboss.org/hudson/";
+	
+	BuildServerDialog buildServerDialog = null;
+	@Test
+	public void getDialogTest() {
+		
+		new ShellMenu("Window", "Show View", "Other...").select();		
+		//DefaultTreeItem taskRepositories = 
+		new DefaultTreeItem ("Mylyn", "Builds").select();
+		new PushButton("OK").click();
+				
+		AbstractWait.sleep(TimePeriod.NORMAL.getSeconds());
+
+		new DefaultToolItem("New Build Server Location").click();
+		
+		new DefaultShell ("New Repository");
+		new DefaultTreeItem ("Hudson (supports Jenkins)").select();
+		new PushButton("Next >").click();
+		
+		new DefaultShell ("New Build Server");
+		new LabeledText ("Server:").setText(SERVERURL);
+		new LabeledText ("Label:").setText(SERVERURL);
+		new PushButton("Finish").click();
+				
+		DefaultTree buildServerTree = new DefaultTree();
+		List<TreeItem> buildServerItems = buildServerTree.getAllItems();
+		
+		ArrayList<String> repoList = new ArrayList<String>();
+		int i = 0;
+		for (TreeItem item : buildServerItems) {
+			repoList.add(i++, item.getText());
+		}
+		int elementIndex = repoList.indexOf(SERVERURL);
+		
+		buildServerItems.get(elementIndex).select();	
+		new ShellMenu("File", "Properties").select();  
+		
+		buildServerDialog = new BuildServerDialog();
+		
+		assertTrue ("Properties title matches", buildServerDialog.getText().equals("Build Server Properties"));
+		
+		buildServerDialog.validateSettings();
+
+		assertTrue("Build Server Properties Invalid", new LabeledText("Build Server Properties").getText().contains("Repository is valid"));
+	
+		buildServerDialog.close();
+		
+		buildServerDialog = null;
+		
+	}
+	
+	@Override
+	public void tearDown(){
+		if (buildServerDialog != null){
+			buildServerDialog.close();
+		}
+	}
+}


### PR DESCRIPTION
The file to be modified is:
- tests/org.jboss.reddeer.eclipse.test/pom.xml - To add a dependency for: org.eclipse.mylyn.hudson.feature.group

The files to be added are:
- plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/MylynBuild.java - New class, this is the build definition
- plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/MylynBuildView.java - New class, this is the build view definition
- tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/mylyn/tasks/ui/view/MylynBuildViewTest.java - New test, for the new build view
