### PR TITLE
WidgetLookup should set workbenchpart as parent if shell is null

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/WidgetLookup.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/WidgetLookup.java
@@ -256,18 +256,17 @@ public class WidgetLookup {
 		Shell activeWorkbenchParentShell = getShellForActiveWorkbench(activeWorkbenchReference);
 		Shell activeShell = ShellLookup.getInstance().getActiveShell();
 
-		if (activeWorkbenchParentShell == null || !activeWorkbenchParentShell.equals(activeShell)){
-			if (activeShell != null){
-				logger.debug("Setting active shell with title \"" + WidgetHandler.getInstance().getText(activeShell) + "\" as the parent");
-				control = activeShell;	
-			}
+		if ((activeWorkbenchParentShell == null || !activeWorkbenchParentShell.equals(activeShell))
+				&& activeShell != null){
+			logger.debug("Setting active shell with title \"" + WidgetHandler.getInstance().getText(activeShell) + "\" as the parent");
+			control = activeShell;	
 		}			
 		else {
 			if (activeWorkbenchReference != null){
 				logger.debug("Setting workbench part with title \"" + getTitle(activeWorkbenchReference) + "\"as the parent");
+				control = WorkbenchLookup.getWorkbenchControl(activeWorkbenchReference);
 			}
-			control = WorkbenchLookup.getWorkbenchControl(activeWorkbenchReference);
-		}
+		}	
 		return control;
 	}
 	


### PR DESCRIPTION
if (activeWorkbenchParentShell == null || !activeWorkbenchParentShell.equals(activeShell)){
            if (activeShell != null){
                logger.debug("Setting active shell with title \"" + WidgetHandler.getInstance().getText(activeShell) + "\" as the parent");
                control = activeShell;  
            }
        }   
