### PR TITLE
LinkHandler sends events in syncexec 

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/LinkHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/LinkHandler.java
@@ -137,7 +137,7 @@ public class LinkHandler {
 	 *            widget to activate
 	 */
 	public void activate(final Link link, final String text) {
-		Display.syncExec(new Runnable() {
+		Display.asyncExec(new Runnable() {
 
 			@Override
 			public void run() {


### PR DESCRIPTION
this is sometimes causing tests to freeze. We have to change it to async
