### PR TITLE
Implemented views extending View are deprecated

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/AbstractExplorer.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/AbstractExplorer.java
@@ -7,7 +7,7 @@ import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
-import org.jboss.reddeer.workbench.view.impl.WorkbenchView;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 
 /**
  * Common ancestor for Package and Project Explorer

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/junit/JUnitView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/junit/JUnitView.java
@@ -2,7 +2,7 @@ package org.jboss.reddeer.eclipse.jdt.ui.junit;
 
 import org.jboss.reddeer.swt.impl.label.DefaultLabel;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
-import org.jboss.reddeer.workbench.view.View;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 
 /**
  * JUnit View
@@ -10,7 +10,7 @@ import org.jboss.reddeer.workbench.view.View;
  * @author apodhrad
  * 
  */
-public class JUnitView extends View {
+public class JUnitView extends WorkbenchView {
 
 	public JUnitView() {
 		super("JUnit");

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskListView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskListView.java
@@ -13,7 +13,7 @@ import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
-import org.jboss.reddeer.workbench.view.View;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 import org.jboss.reddeer.swt.condition.TreeItemHasMinChildren;
 
 /**
@@ -22,7 +22,7 @@ import org.jboss.reddeer.swt.condition.TreeItemHasMinChildren;
  * @author ldimaggi
  *
  */
-public class TaskListView extends View {
+public class TaskListView extends WorkbenchView {
 	
 	public static final String TITLE = "Task List";
 	

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
@@ -15,7 +15,7 @@ import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.text.DefaultText;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.jboss.reddeer.workbench.view.View;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 
 
 /**
@@ -24,7 +24,7 @@ import org.jboss.reddeer.workbench.view.View;
  * @author 
  *
  */
-public class TaskRepositoriesView extends View {
+public class TaskRepositoriesView extends WorkbenchView {
 	
 	public static final String TITLE = "Task Repositories";
 	

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserEditor.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserEditor.java
@@ -7,10 +7,9 @@ import org.jboss.reddeer.swt.impl.browser.InternalBrowser;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
-import org.jboss.reddeer.workbench.editor.DefaultEditor;
-import org.jboss.reddeer.workbench.editor.Editor;
+import org.jboss.reddeer.workbench.impl.editor.AbstractEditor;
 
-public class BrowserEditor extends DefaultEditor implements Editor{
+public class BrowserEditor extends AbstractEditor{
 	
 	private InternalBrowser browser;
 	private static final TimePeriod TIMEOUT = TimePeriod.LONG;

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserView.java
@@ -8,7 +8,7 @@ import org.jboss.reddeer.swt.impl.browser.InternalBrowser;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
-import org.jboss.reddeer.workbench.view.impl.WorkbenchView;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 
 /**
  * Represents Internal Browser view in Eclipse

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/console/ConsoleView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/console/ConsoleView.java
@@ -11,7 +11,7 @@ import org.jboss.reddeer.swt.matcher.WithTextMatcher;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
-import org.jboss.reddeer.workbench.view.impl.WorkbenchView;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 
 /**
  * Represents Console view in Eclipse

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/contentoutline/OutlineView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/contentoutline/OutlineView.java
@@ -5,11 +5,10 @@ import java.util.Collection;
 
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
-import org.jboss.reddeer.swt.impl.toolbar.ViewToolItem;
+import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.matcher.RegexMatcher;
-import org.jboss.reddeer.workbench.view.impl.WorkbenchView;
-
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 /**
  * Represents Outline view in Eclipse
  * 
@@ -66,7 +65,7 @@ public class OutlineView extends WorkbenchView {
 	
 	private void clickOnToolTip(String regex) {
 		RegexMatcher rm = new RegexMatcher(regex);
-		new ViewToolItem(rm).click();
+		new DefaultToolItem(rm).click();
 	}
 	
 }

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogView.java
@@ -16,7 +16,7 @@ import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
-import org.jboss.reddeer.workbench.view.impl.WorkbenchView;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 
 /**
  * Represents Error Log view

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/properties/PropertiesView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/properties/PropertiesView.java
@@ -5,10 +5,9 @@ import java.util.List;
 
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
-import org.jboss.reddeer.swt.impl.toolbar.ViewToolItem;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.jboss.reddeer.workbench.view.impl.WorkbenchView;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 /**
  * Manages Properties View
  * @author Vlado Pakan

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/editor/ServerEditor.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/editor/ServerEditor.java
@@ -1,6 +1,6 @@
 package org.jboss.reddeer.eclipse.wst.server.ui.editor;
 
-import org.jboss.reddeer.workbench.editor.DefaultEditor;
+import org.jboss.reddeer.workbench.impl.editor.AbstractEditor;
 
 /**
  * Represents the editor for server properties. 
@@ -8,7 +8,7 @@ import org.jboss.reddeer.workbench.editor.DefaultEditor;
  * @author Lucia Jelinkova
  *
  */
-public class ServerEditor extends DefaultEditor {
+public class ServerEditor extends AbstractEditor {
 
 	public ServerEditor(String title) {
 		super(title);

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/ServersView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/ServersView.java
@@ -12,7 +12,7 @@ import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.impl.menu.ContextMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
-import org.jboss.reddeer.workbench.view.View;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 
 /**
  * Represents the Servers view. This class contains methods that can be invoked even 
@@ -21,7 +21,7 @@ import org.jboss.reddeer.workbench.view.View;
  * @author Lucia Jelinkova
  *
  */
-public class ServersView extends View {
+public class ServersView extends WorkbenchView {
 
 	public static final String TITLE = "Servers";
 


### PR DESCRIPTION
Bcs. of refactoring in workbench plugin every implemented View (e.g. ServersView) extending View are now deprecated without any information what to do/use. We should fix all such views to let them extend WorkbenchView instead of View (according to message in deprecated View to use WorkbenchView).
