### PR TITLE
Add method to TreeItem that allows setting text to a cell

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/api/TreeItem.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/api/TreeItem.java
@@ -130,5 +130,18 @@ public interface TreeItem extends Widget{
 	 */
 	 boolean isExpanded();
 	 
+	 /**
+	  * Sets tree item text
+	  * @param text to set
+	  * @param index of column
+	  */
+	 void setText(String text, int index);
+	 
+	 /**
+	  * Sets tree item text 
+	  * @param text to set
+	  */
+	 void setText(String text);
+	 
 	 org.eclipse.swt.widgets.TreeItem getSWTWidget();
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TreeItemHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TreeItemHandler.java
@@ -19,7 +19,7 @@ public class TreeItemHandler {
 	}
 
 	/**
-	 * Creates and returns instance of ComboHandler class
+	 * Creates and returns instance of TreeHandler class
 	 * 
 	 * @return
 	 */
@@ -33,15 +33,15 @@ public class TreeItemHandler {
 	/**
 	 * Gets text on given cell index 
 	 * 
-	 * @param tableItem given widget
+	 * @param treeItem given widget
 	 * @Param cellIndex index of cell
 	 * @return returns widget text
 	 */
-	public String getText(final TreeItem tableItem, final int cellIndex) {
+	public String getText(final TreeItem treeItem, final int cellIndex) {
 		String text = Display.syncExec(new ResultRunnable<String>() {
 			@Override
 			public String run() {
-				return tableItem.getText(cellIndex);
+				return treeItem.getText(cellIndex);
 			}
 		});
 		return text;
@@ -75,6 +75,24 @@ public class TreeItemHandler {
 			@Override
 			public Boolean run() {
 				return item.getExpanded();
+			}
+		});
+	}
+	
+	
+	/**
+	 * Sets text on given cell index 
+	 * 
+	 * @param treeItem given widget
+	 * @Param cellIndex index of cell
+	 * @param text to set
+	 */
+	public void setText(final TreeItem treeItem, final int cellIndex, final String text) {
+		Display.syncExec(new Runnable() {
+			
+			@Override
+			public void run() {
+				treeItem.setText(cellIndex, text);
 			}
 		});
 	}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/AbstractTreeItem.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/tree/AbstractTreeItem.java
@@ -224,4 +224,14 @@ public abstract class AbstractTreeItem implements TreeItem {
 	public boolean isEnabled() {
 		return WidgetHandler.getInstance().isEnabled(swtTreeItem);
 	}
+	
+	@Override
+	public void setText(String text, int index){
+		TreeItemHandler.getInstance().setText(swtTreeItem, index, text);
+	}
+	
+	@Override
+	public void setText(String text){
+		TreeItemHandler.getInstance().setText(swtTreeItem, 0, text);
+	}
 }


### PR DESCRIPTION
Currently, there is no way how to set a text into a TreeItem's cell.
e.g., set a text to the cell in column Value:
![tree](https://cloud.githubusercontent.com/assets/4416361/2616117/71d18fde-bc02-11e3-8be7-3741cd4bfdf3.jpg)
[source: https://github.com/jbosstools/jbosstools-webservices/blob/4edef2633be20bd88617401c47b224864dfec0e9/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JaxrsElementChangedProcessorDelegate.java]

In SWTBot, there is a workaround for this problem. SWTBotTreeItem's method click(cellIndex) gains focus to the specified cell, which activates Text widget.

SWTBotTreeItem.click(1); //gain focus to the cell with index 1
bot.text().setText("...");
