### PR TITLE
RedDeer new test plug-in wizard should have disabled Finish till fields are filled

### DIFF
--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/wizards/NewRedDeerTestPluginWizardPage.java
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/wizards/NewRedDeerTestPluginWizardPage.java
@@ -62,6 +62,7 @@ public class NewRedDeerTestPluginWizardPage extends WizardPage implements
 		setImageDescriptor(ImageDescriptor.createFromURL(FileLocator.find(
 				Platform.getBundle(Activator.PLUGIN_ID), new Path(
 						"resources/reddeer_icon.png"), null)));
+		setPageComplete(false);
 
 	}
 


### PR DESCRIPTION
After opening RedDeer new test plug-in wizard there is a wizard page with field for ID, company etc. The Finish button on this page is active by default. Upon typing anything into required field(s) the button goes to disable until all required fields are filled.
