### PR TITLE
Exception in NoShellToClose condition trying to get text of disposed widget

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/shell/WorkbenchShell.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/shell/WorkbenchShell.java
@@ -1,6 +1,7 @@
 package org.jboss.reddeer.swt.impl.shell;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.swt.widgets.Shell;
@@ -136,12 +137,14 @@ public class WorkbenchShell extends AbstractShell {
 		public boolean test() {
 			new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 			shells = getShellsToClose();
-			if (shells.isEmpty()) {
+			if (shells.isEmpty() || shellsAreDisposed(shells)) {
 				return true;
 			}
 			Shell shell = shells.get(shells.size() - 1);
 			beforeShellIsClosed(shell);
-			new DefaultShell(WidgetHandler.getInstance().getText(shell)).close();
+			if (!shell.isDisposed()){
+				new DefaultShell(WidgetHandler.getInstance().getText(shell)).close();
+			}
 			return false;
 		}
 
@@ -149,9 +152,24 @@ public class WorkbenchShell extends AbstractShell {
 		public String description() {
 			List<String> shellTitles = new ArrayList<String>();
 			for (Shell shell: shells) {
-				shellTitles.add(WidgetHandler.getInstance().getText(shell));
+				if (!shell.isDisposed()){
+					shellTitles.add(WidgetHandler.getInstance().getText(shell));
+				}
 			}
 			return "The following shells are still open " + shellTitles;
+		}
+		
+		private boolean shellsAreDisposed(List<Shell> shells){
+			boolean nonDisposedShellExists = false;
+			
+			if (shells != null){
+				Iterator<Shell> itShells = shells.iterator();
+				while (itShells.hasNext() && (!nonDisposedShellExists)){
+					nonDisposedShellExists = !itShells.next().isDisposed();
+				}
+			}
+			
+			return !nonDisposedShellExists;
 		}
 		
 	}


### PR DESCRIPTION
org.jboss.reddeer.swt.exception.SWTLayerException: Runtime error during retrieving widget's text
    at org.jboss.reddeer.swt.handler.WidgetHandler.getText(WidgetHandler.java:292)
    at org.jboss.reddeer.swt.impl.shell.WorkbenchShell$NoShellToClose.description(WorkbenchShell.java:152)
    at org.jboss.reddeer.swt.wait.WaitUntil.wait(WaitUntil.java:62)
    at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:53)
    at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:38)
    at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:30)
    at org.jboss.reddeer.swt.impl.shell.WorkbenchShell.closeAllShells(WorkbenchShell.java:98)
    at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt$WorkbenchShellExt.closeAllShells(CloseAllShellsExt.java:61)
    at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt.runAfterTest(CloseAllShellsExt.java:38)
    at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:66)
    at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
    at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:43)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:106)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
    at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
    at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:85)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:72)
    at java.lang.Thread.run(Thread.java:662)
Caused by: org.jboss.reddeer.swt.exception.SWTLayerException: Exception when invoking method public java.lang.String org.eclipse.swt.widgets.Decorations.getText() by reflection
    at org.jboss.reddeer.swt.util.ObjectUtil.invokeMethod(ObjectUtil.java:75)
    at org.jboss.reddeer.swt.util.ObjectUtil.access$0(ObjectUtil.java:71)
    at org.jboss.reddeer.swt.util.ObjectUtil$1.run(ObjectUtil.java:65)
    at org.jboss.reddeer.swt.util.Display$1.run(Display.java:92)
    at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
    at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:136)
    at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4147)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3764)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1122)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1006)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:147)
    at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:630)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:574)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:125)
    at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:114)
    at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:133)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:103)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:378)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:232)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:648)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:603)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1462)
    at org.eclipse.equinox.launcher.Main.main(Main.java:1438)
Caused by: java.lang.reflect.InvocationTargetException
    at sun.reflect.GeneratedMethodAccessor14.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.reddeer.swt.util.ObjectUtil.invokeMethod(ObjectUtil.java:73)
    ... 32 more
Caused by: org.eclipse.swt.SWTException: Widget is disposed
    at org.eclipse.swt.SWT.error(SWT.java:4441)
    at org.eclipse.swt.SWT.error(SWT.java:4356)
    at org.eclipse.swt.SWT.error(SWT.java:4327)
    at org.eclipse.swt.widgets.Widget.error(Widget.java:476)
    at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:348)
    at org.eclipse.swt.widgets.Decorations.getText(Decorations.java:746)
    ... 36 more
