### PR TITLE
Dependencies versions follow main version

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -9,12 +9,12 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.wst.server.ui,
  org.eclipse.ui.console,
- org.jboss.reddeer.jface;bundle-version="0.4.0",
- org.jboss.reddeer.swt;bundle-version="0.4.0",
- org.jboss.reddeer.workbench;bundle-version="0.4.0",
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.workbench;bundle-version="[0.6,0.7)",
  org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.ui.workbench,
- org.jboss.reddeer.junit;bundle-version="0.4.0",
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
  org.eclipse.wst.server.core
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/org.jboss.reddeer.examples/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.examples/META-INF/MANIFEST.MF
@@ -5,10 +5,10 @@ Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.examples
 Bundle-Version: 0.6.0.qualifier
 Require-Bundle: org.jboss.reddeer.eclipse,
- org.jboss.reddeer.jface,
- org.jboss.reddeer.junit,
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.swt,
- org.jboss.reddeer.workbench,
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.workbench;bundle-version="[0.6,0.7)",
  org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
@@ -7,9 +7,9 @@ Bundle-Version: 0.6.0.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.swt;bundle-version="0.4.0",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.junit;bundle-version="0.4.0"
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.eclipse.jface.exception,

--- a/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
@@ -8,10 +8,10 @@ Bundle-Activator: org.jboss.reddeer.junit.extension.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.apache.commons.logging;bundle-version="1.1.1",
- org.jboss.reddeer.eclipse;bundle-version="0.5.0",
- org.jboss.reddeer.junit;bundle-version="0.5.0",
- org.jboss.reddeer.jface;bundle-version="0.5.0",
- org.jboss.reddeer.swt;bundle-version="0.5.0",
+ org.jboss.reddeer.eclipse;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
  org.junit;bundle-version="4.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .

--- a/plugins/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
@@ -6,10 +6,10 @@ Bundle-Version: 0.6.0.qualifier
 Bundle-Activator: org.jboss.reddeer.requirements.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.junit,
- org.jboss.reddeer.eclipse,
- org.jboss.reddeer.workbench,
- org.jboss.reddeer.swt
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.workbench;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: JBoss by Red Hat

--- a/plugins/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.swt,
- org.jboss.reddeer.junit;bundle-version="0.4.0"
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.swt,org.jboss.reddeer.swt.api,org.jb

--- a/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.launching,
  org.eclipse.debug.ui,
  org.eclipse.pde.ui,
- org.jboss.reddeer.jface;bundle-version="0.4.0",
- org.jboss.reddeer.swt;bundle-version="0.4.0",
- org.jboss.reddeer.workbench;bundle-version="0.4.0"
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.workbench;bundle-version="[0.6,0.7)"
 

--- a/plugins/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
@@ -7,12 +7,12 @@ Bundle-Version: 0.6.0.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.swt;bundle-version="0.4.0",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
  org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.jface.text;bundle-version="3.8.100",
- org.jboss.reddeer.junit;bundle-version="0.4.0",
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
  org.eclipse.ui.editors;bundle-version="3.8.100",
- org.jboss.reddeer.jface
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.workbench,

--- a/tests/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
@@ -9,19 +9,19 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.jdt.debug.ui,
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.eclipse;bundle-version="0.5.0",
- org.jboss.reddeer.jface;bundle-version="0.4.0",
- org.jboss.reddeer.workbench;bundle-version="0.4.0",
- org.jboss.reddeer.swt;bundle-version="0.4.0",
+ org.jboss.reddeer.eclipse;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.workbench;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
  org.eclipse.wst.server.core,
  org.eclipse.debug.core,
  org.eclipse.ui.views.log,
- org.jboss.reddeer.junit;bundle-version="0.4.0",
- org.jboss.reddeer.swt.test;bundle-version="0.4.0",
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt.test;bundle-version="[0.6,0.7)",
  org.eclipse.ui.browser,
  org.eclipse.mylyn.tasks.ui,
- org.jboss.reddeer.requirements,
- org.jboss.reddeer.junit.extension;bundle-version="0.5.0"
+ org.jboss.reddeer.requirements;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.6,0.7)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: org.hamcrest.core

--- a/tests/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
@@ -7,11 +7,11 @@ Bundle-Version: 0.6.0.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.junit,
- org.jboss.reddeer.jface;bundle-version="0.4.0",
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)",
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.swt;bundle-version="0.4.0",
- org.jboss.reddeer.swt.test;bundle-version="0.4.0",
- org.jboss.reddeer.junit.extension;bundle-version="0.5.0"
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt.test;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.6,0.7)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/tests/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
@@ -6,13 +6,12 @@ Bundle-Version: 0.6.0.qualifier
 Bundle-Activator: org.jboss.reddeer.requirements.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.junit;bundle-version="0.4.0",
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
  org.junit;bundle-version="4.10.0",
- org.jboss.reddeer.requirements;bundle-version="0.4.0",
- org.jboss.reddeer.eclipse;bundle-version="0.4.0",
- org.jboss.reddeer.jface;bundle-version="0.4.0",
- org.jboss.reddeer.swt.test;bundle-version="0.4.0",
- org.jboss.reddeer.junit.extension;bundle-version="0.5.0",
- org.jboss.reddeer.junit.extension;bundle-version="0.5.0"
+ org.jboss.reddeer.requirements;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt.test;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.6,0.7)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/tests/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
@@ -8,15 +8,15 @@ Bundle-Activator: org.jboss.reddeer.swt.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.swt;bundle-version="0.4.0",
- org.jboss.reddeer.workbench;bundle-version="0.4.0",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.workbench;bundle-version="[0.6,0.7)",
  org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.core.expressions,
  org.eclipse.ui.views.log,
  org.eclipse.m2e.core.ui,
- org.jboss.reddeer.eclipse;bundle-version="0.4.0",
- org.jboss.reddeer.junit;bundle-version="0.4.0",
- org.jboss.reddeer.junit.extension;bundle-version="0.5.0"
+ org.jboss.reddeer.eclipse;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.6,0.7)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.swt.test

--- a/tests/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
@@ -7,13 +7,13 @@ Bundle-Activator: org.jboss.reddeer.uiforms.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.ui.forms,
- org.jboss.reddeer.swt,
- org.jboss.reddeer.swt.test,
- org.jboss.reddeer.workbench,
- org.jboss.reddeer.uiforms,
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt.test;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.workbench;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.uiforms;bundle-version="[0.6,0.7)",
  org.hamcrest.core;bundle-version="1.3.0",
  org.junit,
- org.jboss.reddeer.junit.extension;bundle-version="0.5.0"
+ org.jboss.reddeer.junit.extension;bundle-version="[0.6,0.7)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.uiforms.test

--- a/tests/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
@@ -6,16 +6,16 @@ Bundle-SymbolicName: org.jboss.reddeer.workbench.test;singleton:=true
 Bundle-Version: 0.6.0.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.test.Activator
 Require-Bundle: org.eclipse.ui,
- org.jboss.reddeer.workbench;bundle-version="0.4.0",
- org.jboss.reddeer.swt;bundle-version="0.4.0",
+ org.jboss.reddeer.workbench;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.swt;bundle-version="[0.6,0.7)",
  org.eclipse.core.runtime,
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.swt.test;bundle-version="0.4.0",
- org.jboss.reddeer.eclipse;bundle-version="0.4.0",
- org.jboss.reddeer.jface;bundle-version="0.4.0",
+ org.jboss.reddeer.swt.test;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.jface;bundle-version="[0.6,0.7)",
  org.eclipse.jface.text;bundle-version="3.8.100",
- org.jboss.reddeer.junit.extension;bundle-version="0.5.0",
- org.jboss.reddeer.direct;bundle-version="0.5.0"
+ org.jboss.reddeer.junit.extension;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.direct;bundle-version="[0.6,0.7)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: org.eclipse.ui.texteditor


### PR DESCRIPTION
RedDeer dependencies should follow RedDeer version, it means that for RedDeer 0.6 all plugins used should be in version <0.6,0.7]
