### PR TITLE
Server requirements runtime should be optional.

### DIFF
--- a/plugins/org.jboss.reddeer.requirements/resources/ServerRequirementsBase.xsd
+++ b/plugins/org.jboss.reddeer.requirements/resources/ServerRequirementsBase.xsd
@@ -22,7 +22,7 @@
 				<xs:sequence>
 					<xs:element name="type" maxOccurs="1" minOccurs="1"
 						type="server:serverType" />
-					<xs:element name="runtime" type="xs:string" minOccurs="1"
+					<xs:element name="runtime" type="xs:string" minOccurs="0"
 						maxOccurs="1" />
 				</xs:sequence>
 			</xs:extension>


### PR DESCRIPTION
There are some use cases when it makes sense to not fill in the runtime path e.g. when defining remote server. 
