### PR TITLE
Fail in @AfterClass is displayed in wrong node

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunner.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunner.java
@@ -93,6 +93,11 @@ public class RequirementsRunner extends BlockJUnit4ClassRunner {
 	}
 	
 	@Override
+	protected String getName() {
+		return super.getName() + " " + configId;
+	}
+	
+	@Override
 	public void run(RunNotifier arg0) {
 		LoggingRunListener loggingRunListener = new LoggingRunListener();
 		ScreenCastingRunListener screenCastingRunListener = new ScreenCastingRunListener();


### PR DESCRIPTION
Imagine simple test with configurations as follows:
![junittree](https://cloud.githubusercontent.com/assets/1215011/2877895/d07640c4-d454-11e3-9dfd-16fb34ec0325.png)

And test class ExamplesTest has defined @AfterClass which fails. The failure is shown on wrong node (on the screenshot: @AfterClass method of ExamplesTest for confirugarion EAP62.xml  failed, but it was shown in wildfly8.xml configuration (blue failure mark))
