### PR TITLE
JUnit Tests are not built properly - empty jar

### DIFF
--- a/tests/org.jboss.reddeer.junit.test/pom.xml
+++ b/tests/org.jboss.reddeer.junit.test/pom.xml
@@ -14,12 +14,6 @@
 
 
 	<build>
-		<sourceDirectory>src/main/java</sourceDirectory>
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-			</resource>
-		</resources>
 		<testSourceDirectory>src/test/java</testSourceDirectory>
 		<testResources>
 			<testResource>


### PR DESCRIPTION
When you build JUnit tests (org.jboss.reddeer.junit.test) bundle, the resulting jar is almost empty. Because of this, it cannot be included in the test feature on our p2 repo.
