### PR TITLE
Luna M7 causes problems with running tests on macosx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 	
 	<properties>
- 	   	<tycho-version>0.18.1</tycho-version>  	  
+ 	   	<tycho-version>0.20.0</tycho-version>  	  
 		<tychoExtrasVersion>${tycho-version}</tychoExtrasVersion>
 		<eclipse-target-site>http://download.eclipse.org/releases/luna</eclipse-target-site>
 		<swtbot-update-site>http://download.eclipse.org/technology/swtbot/releases/2.2.1</swtbot-update-site>


### PR DESCRIPTION
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-surefire-plugin:0.18.1:test (default-test) on project org.jboss.reddeer.swt.test: Execution default-test of goal org.eclipse.tycho:tycho-surefire-plugin:0.18.1:test failed: Exception parsing OSGi MANIFEST /Users/jbossqa/.m2/repository/p2/osgi/bundle/org.eclipse.jdt.annotation/2.0.0.v20140415-1436/org.eclipse.jdt.annotation-2.0.0.v20140415-1436.jar!/META-INF/MANIFEST.MF: Unknown OSGi execution environment: 'JavaSE-1.8' -> [Help 1]
