### PR TITLE
Update tycho to 0.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 	
 	<properties>
- 	   	<tycho-version>0.18.1</tycho-version>  	  
+ 	   	<tycho-version>0.20.0</tycho-version>  	  
 		<tychoExtrasVersion>${tycho-version}</tychoExtrasVersion>
 		<eclipse-target-site>http://download.eclipse.org/releases/luna</eclipse-target-site>
 		<swtbot-update-site>http://download.eclipse.org/technology/swtbot/releases/2.2.1</swtbot-update-site>


### PR DESCRIPTION
This upgrade is useful for us because if fixes a problem where RedDeer tests
failed on Mac due to unrecognized java 8 settings in JDT annotations bundle.
