### PR TITLE
Extend getEditorByTitle by matching with part name

### DIFF
--- a/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/lookup/WorkbenchPartLookup.java
+++ b/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/lookup/WorkbenchPartLookup.java
@@ -68,8 +68,9 @@ public class WorkbenchPartLookup {
 				IEditorReference[] editors = activeWorkbenchWindow
 						.getActivePage().getEditorReferences();
 				for (IEditorReference iEditorReference : editors) {
-
-					if (title.matches(iEditorReference.getEditor(false).getEditorInput().getName())) {
+					if (title.matches(iEditorReference.getPartName())) {
+						return iEditorReference.getEditor(false);
+					} else if (title.matches(iEditorReference.getEditor(false).getEditorInput().getName())) {
 						return iEditorReference.getEditor(false);
 					} else if (title.matches(iEditorReference.getEditor(false).getEditorInput().getToolTipText())) {
 						return iEditorReference.getEditor(false);


### PR DESCRIPTION
Now the implementation looks for the title in
1. editor input's name
2. editor input's tooltip

I suggest to extend this implementation by looking also in part name (the name shown in the tab). Current implementation doesn't work with Graphiti Diagram Editor (Graphiti Examples Feature) where is only the part name defined.

![graphitieditor](https://cloud.githubusercontent.com/assets/2270674/2985211/a086ae74-dc3a-11e3-86bc-a6e3eeb07fc5.png)
