### PR TITLE
CloseAllShellExt cant close some shells

### DIFF
--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
@@ -1,6 +1,8 @@
 package org.jboss.reddeer.workbench.test.editor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.awt.AWTException;
 import java.io.IOException;
@@ -23,13 +25,17 @@ import org.jboss.reddeer.eclipse.ui.ide.NewFileCreationWizardDialog;
 import org.jboss.reddeer.eclipse.ui.ide.NewFileCreationWizardPage;
 import org.jboss.reddeer.eclipse.ui.wizards.datatransfer.ExternalProjectImportWizardDialog;
 import org.jboss.reddeer.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.handler.ShellHandler;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.keyboard.KeyboardFactory;
+import org.jboss.reddeer.swt.lookup.ShellLookup;
 import org.jboss.reddeer.swt.test.RedDeerTest;
 import org.jboss.reddeer.swt.util.Display;
-import org.jboss.reddeer.workbench.impl.editor.DefaultEditor;
-import org.jboss.reddeer.workbench.impl.editor.TextEditor;
 import org.jboss.reddeer.workbench.exception.WorkbenchLayerException;
 import org.jboss.reddeer.workbench.exception.WorkbenchPartNotFound;
+import org.jboss.reddeer.workbench.impl.editor.DefaultEditor;
+import org.jboss.reddeer.workbench.impl.editor.TextEditor;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -105,6 +111,38 @@ public class TextEditorTest extends RedDeerTest {
 		assertTrue(ca.getProposals().contains("enum"));
 		ca.chooseProposal("enum");
 		assertTrue(textEditor.getText().contains("enum"));
+	}
+	
+	@Test
+	public void closeContentAssist(){
+		openJavaFile();
+		TextEditor textEditor = new TextEditor();
+		ContentAssistant ca = textEditor.openContentAssistant();
+		ca.close();
+		
+		try {
+			new DefaultShell("");
+			fail("ContentAssistant wasn't close");
+		} catch (SWTLayerException e) {
+			// ok, this is expected
+		}
+	}
+
+	@Test
+	public void closeContentAssistUsingCloseAllShells(){
+		openJavaFile();
+		TextEditor textEditor = new TextEditor();
+		ContentAssistant ca = textEditor.openContentAssistant();
+		ShellHandler.getInstance().closeAllNonWorbenchShells();
+
+		try {
+			new DefaultShell("");
+			// if content assistant is still available then close it
+			ca.close();
+			fail("ContentAssistant wasn't close");
+		} catch (SWTLayerException e) {
+			// ok, this is expected
+		}
 	}
 
 	@Test


### PR DESCRIPTION
![screenshot from 2014-05-16 10 52 27](https://cloud.githubusercontent.com/assets/2078045/2995069/89dbe1e2-dcd7-11e3-9a24-cb8804e90830.png)

java.lang.AssertionError: The following shells remained open [Assignable Beans]
    at org.junit.Assert.fail(Assert.java:88)
    at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt.runAfterTest(CloseAllShellsExt.java:42)
    at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:66)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
    at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:43)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:106)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
    at org.jboss.reddeer.eclipse.core.RemotePluginTestRunner.main(RemotePluginTestRunner.java:56)
    at org.jboss.reddeer.eclipse.core.UITestApplication.runTests(UITestApplication.java:115)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:72)
    at java.lang.Thread.run(Thread.java:744)
