### PR TITLE
NullPointer in MenuLookup

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/MenuLookup.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/MenuLookup.java
@@ -142,7 +142,9 @@ public class MenuLookup {
 	 */
 	public MenuItem lookFor(MenuItem[] topItems, Matcher<String>... matchers) {		
 		MenuItem lastMenuItem = getMatchingMenuPath(topItems, matchers);
-		if (lastMenuItem == null) throw new SWTLayerException("");
+		if (lastMenuItem == null) {
+			throw new SWTLayerException("No menu item matching specified path found");
+		}
 		return lastMenuItem;
 	}
 	
@@ -385,6 +387,9 @@ public class MenuLookup {
 							currentMenu = i.getMenu();
 							break;
 						} 
+					}
+					if (currentItem == null){
+						return null;
 					}
 					if (m != matchers[matchers.length-1]) {
 						currentMenu = currentItem.getMenu();


### PR DESCRIPTION
Error Message

Failed to execute runnable (java.lang.NullPointerException)

Stacktrace

org.eclipse.swt.SWTException: Failed to execute runnable (java.lang.NullPointerException)
    at org.eclipse.swt.SWT.error(SWT.java:4441)
    at org.eclipse.swt.SWT.error(SWT.java:4356)
    at org.eclipse.swt.widgets.Synchronizer.syncExec(Synchronizer.java:209)
    at org.eclipse.ui.internal.UISynchronizer.syncExec(UISynchronizer.java:150)
    at org.eclipse.swt.widgets.Display.syncExec(Display.java:4561)
    at org.jboss.reddeer.swt.util.Display.syncExec(Display.java:68)
    at org.jboss.reddeer.swt.lookup.MenuLookup.getMatchingMenuPath(MenuLookup.java:370)
    at org.jboss.reddeer.swt.lookup.MenuLookup.lookFor(MenuLookup.java:144)
    at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:45)
    at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:36)
    at org.jboss.ide.eclipse.as.reddeer.server.view.JBossServerModule.openWebPage(JBossServerModule.java:22)
    at org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate.deployProject(DeployJSPProjectTemplate.java:76)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner$InvokeMethodWithException.evaluate(RequirementsRunner.java:288)
    at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:48)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:106)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
    at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
    at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:86)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:72)
    at java.lang.Thread.run(Thread.java:722)
Caused by: java.lang.NullPointerException
    at org.jboss.reddeer.swt.lookup.MenuLookup$13.run(MenuLookup.java:390)
    at org.jboss.reddeer.swt.lookup.MenuLookup$13.run(MenuLookup.java:1)
    at org.jboss.reddeer.swt.util.Display$1.run(Display.java:72)
    at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
    at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:136)
    at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3748)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3396)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1122)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1006)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:147)
    at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:630)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:574)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:125)
    at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:114)
    at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:133)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:103)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:378)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:232)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:648)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:603)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1462)
    at org.eclipse.equinox.launcher.Main.main(Main.java:1438)
