### PR TITLE
Review and update missing javadoc for org.jboss.reddeer.eclipse plugin

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/BrowserHasURL.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/BrowserHasURL.java
@@ -5,6 +5,9 @@ import org.jboss.reddeer.eclipse.ui.browser.BrowserEditor;
 import org.jboss.reddeer.eclipse.ui.browser.BrowserView;
 import org.jboss.reddeer.swt.condition.WaitCondition;
 
+/**
+ * Wait condition which returns true if a given browser has the specified URL.
+ */
 public class BrowserHasURL implements WaitCondition {
 
 	private BrowserView browser;
@@ -12,21 +15,45 @@ public class BrowserHasURL implements WaitCondition {
 	private String expectedURL;
 	private Matcher<String> expectedURLMatcher;
 	
+	/**
+	 * Construct a condition with a given browser view and expected URL.
+	 * 
+	 * @param browser Browser view
+	 * @param expectedURL Expected URL
+	 */
 	public BrowserHasURL(BrowserView browser,String expectedURL){
 		this.browser = browser;
 		this.expectedURL = expectedURL;
 	}
 	
+	/**
+	 * Construct a condition with a given browser view and URL matcher.
+	 * 
+	 * @param browser Browser view
+	 * @param expectedURLMatcher URL matcher
+	 */
 	public BrowserHasURL(BrowserView browser,Matcher<String> expectedURLMatcher){
 		this.browser = browser;
 		this.expectedURLMatcher = expectedURLMatcher;
 	}
 	
+	/**
+	 * Construct a condition with a given browser editor and expected URL.
+	 * 
+	 * @param browser Browser editor
+	 * @param expectedURL Expected URL
+	 */
 	public BrowserHasURL(BrowserEditor browser,String expectedURL){
 		this.browserEditor = browser;
 		this.expectedURL = expectedURL;
 	}
 	
+	/**
+	 * Construct a condition with a given browser editor and URL matcher.
+	 * 
+	 * @param browser Browser editor
+	 * @param expectedURL URL matcher
+	 */
 	public BrowserHasURL(BrowserEditor browser,Matcher<String> expectedURLMatcher){
 		this.browserEditor = browser;
 		this.expectedURLMatcher = expectedURLMatcher;

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ConsoleHasText.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ConsoleHasText.java
@@ -13,6 +13,11 @@ public class ConsoleHasText implements WaitCondition {
 
 	private String text;
 
+	/**
+	 * Construct the condition with a given text.
+	 * 
+	 * @param text Text
+	 */
 	public ConsoleHasText(String text) {
 		this.text = text;
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ProblemsExists.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ProblemsExists.java
@@ -27,6 +27,11 @@ public class ProblemsExists implements WaitCondition {
 		this(false);
 	}
 
+	/**
+	 * Construct the condition with a given problem type checking.
+	 * 
+	 * @param bothProblemTypes If true is specified then there must be at least one error and at least one warning.
+	 */
 	public ProblemsExists(boolean bothProblemTypes) {
 		if (bothProblemTypes) {
 			problemType = ProblemType.BOTH;
@@ -35,6 +40,11 @@ public class ProblemsExists implements WaitCondition {
 		}
 	}
 
+	/**
+	 * Construct the condition with a given problem type checking.
+	 * 
+	 * @param problemType Problem type
+	 */
 	public ProblemsExists(ProblemType problemType) {
 		this.problemType = problemType;
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/RemoteSystemExists.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/RemoteSystemExists.java
@@ -14,6 +14,11 @@ public class RemoteSystemExists implements WaitCondition {
 
 	private String name;
 	
+	/**
+	 * Constructs the condition with a given text.
+	 * 
+	 * @param name Name
+	 */
 	public RemoteSystemExists(String name) {
 		this.name = name;
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/RemoteSystemIsConnected.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/RemoteSystemIsConnected.java
@@ -13,6 +13,11 @@ public class RemoteSystemIsConnected implements WaitCondition {
 
 	private System system;
 	
+	/**
+	 * Construct the condition with a given system.
+	 * 
+	 * @param system System
+	 */
 	public RemoteSystemIsConnected(System system) {
 		this.system = system;
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ServerExists.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ServerExists.java
@@ -14,6 +14,11 @@ public class ServerExists implements WaitCondition {
 
 	private String name;
 	
+	/**
+	 * Construct the condition with a given name.
+	 * 
+	 * @param name Name
+	 */
 	public ServerExists(String name) {
 		this.name = name;
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/preference/DriverDefinitionPreferencePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/preference/DriverDefinitionPreferencePage.java
@@ -16,10 +16,18 @@ import org.jboss.reddeer.workbench.preference.WorkbenchPreferencePage;
  */
 public class DriverDefinitionPreferencePage extends WorkbenchPreferencePage {
 
+	/**
+	 * Construct a preference page with Data Management > Connectivity > Driver Definitions.
+	 */
 	public DriverDefinitionPreferencePage() {
 		super("Data Management", "Connectivity", "Driver Definitions");
 	}
 
+	/**
+	 * Returns all available driver definitions. Not yet implemented!
+	 * 
+	 * @return List of driver definitions
+	 */
 	public List<DriverDefinition> getDriverDefinitions() {
 		throw new UnsupportedOperationException();
 	}
@@ -35,10 +43,16 @@ public class DriverDefinitionPreferencePage extends WorkbenchPreferencePage {
 		return new DriverDefinitionWizard();
 	}
 
+	/**
+	 * Edits the driver definition. Not yet implemented!
+	 */
 	public void editDriverDefinition() {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * Removes the driver definition. Not yet implemented!
+	 */
 	public void removeDriverDefinition() {
 		throw new UnsupportedOperationException();
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/ConnectionProfileDatabasePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/ConnectionProfileDatabasePage.java
@@ -6,8 +6,7 @@ import org.jboss.reddeer.swt.impl.combo.LabeledCombo;
 /**
  * An abstract wizard page for database connection profile.
  * 
- * IMPORTANT: It is assumed that the appropriate driver definition has been
- * already created.
+ * IMPORTANT: It is assumed that the appropriate driver definition has been already created.
  * 
  * @author apodhrad
  * 
@@ -19,22 +18,63 @@ public abstract class ConnectionProfileDatabasePage extends WizardPage {
 	protected ConnectionProfileDatabasePage() {
 		super();
 	}
-	
+
+	/**
+	 * Returns the driver name.
+	 * 
+	 * @return Driver name.
+	 */
 	public String getDriver() {
 		return new LabeledCombo(LABEL_DRIVER).getText();
 	}
 
+	/**
+	 * Sets the specified driver name.
+	 * 
+	 * @param driver
+	 *            Driver name
+	 */
 	public void setDriver(String driver) {
 		new LabeledCombo(LABEL_DRIVER).setSelection(driver);
 	}
 
+	/**
+	 * Sets a given database.
+	 * 
+	 * @param database
+	 *            Database
+	 */
 	public abstract void setDatabase(String database);
 
+	/**
+	 * Sets a given hostname.
+	 * 
+	 * @param hostname
+	 *            Hostname
+	 */
 	public abstract void setHostname(String hostname);
 
+	/**
+	 * Sets a given port.
+	 * 
+	 * @param port
+	 *            Port
+	 */
 	public abstract void setPort(String port);
 
+	/**
+	 * Sets a given user name.
+	 * 
+	 * @param username
+	 *            User name
+	 */
 	public abstract void setUsername(String username);
 
+	/**
+	 * Sets a given password.
+	 * 
+	 * @param password
+	 *            Password
+	 */
 	public abstract void setPassword(String password);
 }

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/ConnectionProfileOraclePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/ConnectionProfileOraclePage.java
@@ -35,10 +35,14 @@ public class ConnectionProfileOraclePage extends ConnectionProfileDatabasePage {
 		return new LabeledText(LABEL_HOST).getText();
 	}
 
+	/**
+	 * Tests the database connection. Not yet implemented!
+	 */
 	public void testConnection() {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void setDatabase(String database) {
 		new LabeledText(LABEL_DATABASE).setText(database);
 	}
@@ -64,6 +68,7 @@ public class ConnectionProfileOraclePage extends ConnectionProfileDatabasePage {
 		return new LabeledText(LABEL_PASSWORD).getText();
 	}
 
+	@Override
 	public void setPassword(String password) {
 		new LabeledText(LABEL_PASSWORD).setText(password);
 		new CheckBox(LABEL_SAVE_PASSWORD).click();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/ConnectionProfileSelectPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/ConnectionProfileSelectPage.java
@@ -20,14 +20,32 @@ public class ConnectionProfileSelectPage extends WizardPage {
 		super();
 	}
 
+	/**
+	 * Sets a given connection profile.
+	 * 
+	 * @param connectionProfile
+	 *            Connection profile
+	 */
 	public void setConnectionProfile(String connectionProfile) {
 		new DefaultTable().select(connectionProfile);
 	}
 
+	/**
+	 * Sets a given name.
+	 * 
+	 * @param name
+	 *            Name
+	 */
 	public void setName(String name) {
 		new LabeledText(LABEL_NAME).setText(name);
 	}
 
+	/**
+	 * Sets a given description.
+	 * 
+	 * @param description
+	 *            Description
+	 */
 	public void setDescription(String description) {
 		new LabeledText(LABEL_DESCRIPTION).setText(description);
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/DriverDefinitionPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/wizard/DriverDefinitionPage.java
@@ -29,7 +29,7 @@ public class DriverDefinitionPage extends WizardPage {
 	public DriverDefinitionPage() {
 		super();
 	}
-	
+
 	/**
 	 * Set a driver name.
 	 * 
@@ -59,6 +59,12 @@ public class DriverDefinitionPage extends WizardPage {
 		}
 	}
 
+	/**
+	 * Sets a given driver class. Not yet implemented!
+	 * 
+	 * @param driverClass
+	 *            Driver class
+	 */
 	public void setDriverClass(String driverClass) {
 		// selectTab(TAB_PROPERTIES);
 		// Tree tree = new ShellTree();
@@ -93,7 +99,7 @@ public class DriverDefinitionPage extends WizardPage {
 	 * @param driverLocation
 	 */
 	public void removeDriverLibrary(String driverLocation) {
-		new DefaultList().select(driverLocation);	
+		new DefaultList().select(driverLocation);
 		new PushButton(BUTTON_REMOVE_JAR).click();
 	}
 
@@ -129,14 +135,14 @@ public class DriverDefinitionPage extends WizardPage {
 	 *
 	 */
 	private class ExtendedDeafultList extends DefaultList {
-		
+
 		public ExtendedDeafultList() {
 			super();
 		}
-		
+
 		public void addItem(final String item) {
 			Display.syncExec(new Runnable() {
-				
+
 				@Override
 				public void run() {
 					list.add(item);

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewAnnotationCreationWizard.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewAnnotationCreationWizard.java
@@ -2,12 +2,18 @@ package org.jboss.reddeer.eclipse.jdt.ui;
 
 import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
 
-public class NewAnnotationCreationWizard extends NewWizardDialog{
-	
+/**
+ * Wizard dialog for creating an annotation.
+ */
+public class NewAnnotationCreationWizard extends NewWizardDialog {
+
+	/**
+	 * Constructs the wizard with Java > Annotation.
+	 */
 	public NewAnnotationCreationWizard() {
 		super("Java", "Annotation");
 	}
-	
+
 	@Override
 	public NewAnnotationWizardPage getFirstPage() {
 		return new NewAnnotationWizardPage();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewAnnotationWizardPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewAnnotationWizardPage.java
@@ -5,44 +5,99 @@ import org.jboss.reddeer.swt.impl.button.CheckBox;
 import org.jboss.reddeer.swt.impl.button.RadioButton;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 
+/**
+ * Wizard page for creating an annotation.
+ */
 public class NewAnnotationWizardPage extends WizardPage {
-	
+
+	/**
+	 * Sets a given package name.
+	 * 
+	 * @param packageName
+	 *            Package name
+	 */
 	public void setPackage(String packageName) {
 		new LabeledText("Package:").setText(packageName);
 	}
-	
-	public void setSourceFolder(String sourceFolder){
+
+	/**
+	 * Sets a given source folder.
+	 * 
+	 * @param sourceFolder
+	 *            Source folder
+	 */
+	public void setSourceFolder(String sourceFolder) {
 		new LabeledText("Source folder:").setText(sourceFolder);
 	}
-	
-	public void setEnclosingType(boolean enclosing){
+
+	/**
+	 * Sets a given enclosing type.
+	 * 
+	 * @param enclosing
+	 *            Eclosing type
+	 */
+	public void setEnclosingType(boolean enclosing) {
 		new CheckBox("Enclosing type:").toggle(enclosing);
 	}
-	
-	public void setName(String name){
+
+	/**
+	 * Sets a given name.
+	 * 
+	 * @param name
+	 *            Name
+	 */
+	public void setName(String name) {
 		new LabeledText("Name:").setText(name);
 	}
-	
-	public void setGenerateComments(boolean generate){
+
+	/**
+	 * Sets generating comments.
+	 * 
+	 * @param generate
+	 *            Indicates whether to generate comments
+	 */
+	public void setGenerateComments(boolean generate) {
 		new CheckBox("Generate comments").toggle(generate);
 	}
-	
-	public void setPublic(boolean isPublic){
+
+	/**
+	 * Sets public visibility
+	 * 
+	 * @param isPublic
+	 *            Is public?
+	 */
+	public void setPublic(boolean isPublic) {
 		new RadioButton("public").toggle(isPublic);
 	}
-	
-	public void setDefault(boolean isDefault){
+
+	/**
+	 * Sets default visibility.
+	 * 
+	 * @param isDefault
+	 *            Is default?
+	 */
+	public void setDefault(boolean isDefault) {
 		new RadioButton("default").toggle(isDefault);
 	}
-	
-	public void setPrivate(boolean isPrivate){
+
+	/**
+	 * Sets private visibility.
+	 * 
+	 * @param isPrivate
+	 *            Is private?
+	 */
+	public void setPrivate(boolean isPrivate) {
 		new RadioButton("private").toggle(isPrivate);
 	}
 
-	public void setProtected(boolean isProtected){
+	/**
+	 * Sets protected visibility.
+	 * 
+	 * @param isProtected
+	 *            Is protected?
+	 */
+	public void setProtected(boolean isProtected) {
 		new RadioButton("protected").toggle(isProtected);
 	}
-	
-	
 
 }

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewEnumWizardDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewEnumWizardDialog.java
@@ -4,16 +4,20 @@ import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
 
 /**
  * Represents new enum wizard
+ * 
  * @author rawagner
  *
  */
-public class NewEnumWizardDialog extends NewWizardDialog{
-	
+public class NewEnumWizardDialog extends NewWizardDialog {
+
+	/**
+	 * Construct the wizard with Java > Enum.
+	 */
 	public NewEnumWizardDialog() {
 		super("Java", "Enum");
 		addWizardPage(new NewEnumWizardPage(), 0);
 	}
-	
+
 	@Override
 	public NewEnumWizardPage getFirstPage() {
 		return new NewEnumWizardPage();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewJavaClassWizardDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewJavaClassWizardDialog.java
@@ -2,8 +2,14 @@ package org.jboss.reddeer.eclipse.jdt.ui;
 
 import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
 
+/**
+ * Wizard dialog for creating a java class.
+ */
 public class NewJavaClassWizardDialog extends NewWizardDialog {
 	
+	/**
+	 * Constructs the wizard with Java > Class.
+	 */
 	public NewJavaClassWizardDialog() {
 		super("Java", "Class");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewJavaClassWizardPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/NewJavaClassWizardPage.java
@@ -5,6 +5,9 @@ import org.jboss.reddeer.eclipse.jface.wizard.WizardPage;
 import org.jboss.reddeer.swt.impl.button.CheckBox;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 
+/**
+ * Wizard page for creating a java class.
+ */
 public class NewJavaClassWizardPage extends WizardPage {
 
 	/**
@@ -24,31 +27,66 @@ public class NewJavaClassWizardPage extends WizardPage {
 		super();
 	}
 	
+	/**
+	 * Sets a given name.
+	 * 
+	 * @param name Name
+	 */
 	public void setName(String name){
 		new LabeledText("Name:").setText(name);
 	}
 	
+	/**
+	 * Sets a given package name.
+	 * 
+	 * @param packageName Package name
+	 */
 	public void setPackage(String packageName) {
 		new LabeledText("Package:").setText(packageName);
 	}
 	
+	/**
+	 * Sets a given source folder.
+	 * 
+	 * @param sourceFolder Source folder
+	 */
 	public void setSourceFolder(String sourceFolder){
 		new LabeledText("Source folder:").setText(sourceFolder);
 	}
 	
+	/**
+	 * Sets generating static main method.
+	 * 
+	 * @param setMainMethod Indicates whether to generate static main method
+	 */
 	public void setStaticMainMethod(boolean setMainMethod) {
 //		new CheckBox("public static void main(String[] args)").toggle(setMainMethod);
 		new CheckBox(4).toggle(setMainMethod); // initiate with label doesnt work
 	}
 	
+	/**
+	 * Returns a package name.
+	 * 
+	 * @return package name
+	 */
 	public String getPackage(){
 		return new LabeledText("Package:").getText();
 	}
 	
+	/**
+	 * Returns a class name.
+	 * 
+	 * @return Class name
+	 */
 	public String getName(){
 		return new LabeledText("Name:").getText();
 	}
 	
+	/**
+	 * Returns a source folder.
+	 * 
+	 * @return Source folder
+	 */
 	public String getSourceFolder(){
 		return new LabeledText("Source folder:").getText();
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ProjectExplorer.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ProjectExplorer.java
@@ -8,6 +8,9 @@ package org.jboss.reddeer.eclipse.jdt.ui;
  */
 public class ProjectExplorer extends AbstractExplorer {
 
+	/**
+	 * Construct the wizard with Project Explorer.
+	 */
 	public ProjectExplorer() {
 		super("Project Explorer");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardDialog.java
@@ -11,8 +11,14 @@ import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 
+/**
+ * Wizard dialog for creating new Java project. 
+ */
 public class NewJavaProjectWizardDialog extends NewWizardDialog{
 	
+	/**
+	 * Constructs the wizard with Java > Java Project.
+	 */
 	public NewJavaProjectWizardDialog() {
 		super("Java", "Java Project");
 		addWizardPage(new NewJavaProjectWizardPage(), 0);
@@ -28,6 +34,10 @@ public class NewJavaProjectWizardDialog extends NewWizardDialog{
 		finish(false);
 	}
 	
+	/**
+	 * 
+	 * @param openAssociatedPerspective
+	 */
 	public void finish(boolean openAssociatedPerspective) {
 		log.debug("Finish wizard dialog");
 		new PushButton("Finish").click();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardPage.java
@@ -12,20 +12,38 @@ import org.jboss.reddeer.swt.impl.text.LabeledText;
  */
 
 public class NewJavaProjectWizardPage extends WizardPage {
-	
-	public void setProjectName (String projectName){
-	    log.debug("Set General Project name to " + projectName);
-	    new LabeledText("Project name:").setText(projectName);
+
+	/**
+	 * Sets a given project name.
+	 * 
+	 * @param projectName
+	 *            Project name
+	 */
+	public void setProjectName(String projectName) {
+		log.debug("Set General Project name to " + projectName);
+		new LabeledText("Project name:").setText(projectName);
 	}
-	
-	public void useDefaultLocation(boolean check){
+
+	/**
+	 * Sets whether to use default location.
+	 * 
+	 * @param check
+	 *            Indicates whether to use dafualt location
+	 */
+	public void useDefaultLocation(boolean check) {
 		CheckBox box = new CheckBox("Use default location");
-		log.debug("Setting default location to "+check);
+		log.debug("Setting default location to " + check);
 		box.toggle(check);
 	}
-	
-	public void setLocation(String location){
-		log.debug("Setting Location to "+location);
+
+	/**
+	 * Sets a given location.
+	 * 
+	 * @param location
+	 *            Location
+	 */
+	public void setLocation(String location) {
+		log.debug("Setting Location to " + location);
 		LabeledText text = new LabeledText("Location:");
 		text.setText(location);
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/junit/JUnitView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/junit/JUnitView.java
@@ -12,6 +12,9 @@ import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
  */
 public class JUnitView extends WorkbenchView {
 
+	/**
+	 * Construct the view with JUnit.
+	 */
 	public JUnitView() {
 		super("JUnit");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/PackageExplorer.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/PackageExplorer.java
@@ -10,6 +10,9 @@ import org.jboss.reddeer.eclipse.jdt.ui.AbstractExplorer;
  */
 public class PackageExplorer extends AbstractExplorer {
     
+	/**
+	 * Constructs the view with Package Explorer.
+	 */
 	public PackageExplorer() {
 		super("Package Explorer");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/ProjectItem.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/ProjectItem.java
@@ -25,19 +25,31 @@ public class ProjectItem {
 	protected TreeItem treeItem;
 	private Project project;
 	private String[] path;
-	
 
+	/**
+	 * Constructs a project item with a given tree item, project and path.
+	 * 
+	 * @param treeItem Tree item
+	 * @param project Project
+	 * @param path Path
+	 */
 	public ProjectItem(TreeItem treeItem, Project project, String... path) {
 		this.treeItem = treeItem;
 		this.path = path;
 		this.project = project;
 	}
 
+	/**
+	 * Opens the project item.
+	 */
 	public void open() {
 		select();
 		treeItem.doubleClick();
 	}
 
+	/**
+	 * Deletes the project. The project is refreshed before deleting.
+	 */
 	public void delete() {
 		refresh();
         log.debug("Delete project item " + treeItem.getText() + " via Package Explorer");
@@ -48,6 +60,9 @@ public class ProjectItem {
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 	}
 
+	/**
+	 * Selects the project.
+	 */
 	public void select() {
 		TreeItem item = project.getTreeItem();
 		int index = 0;
@@ -58,16 +73,30 @@ public class ProjectItem {
 		item.select();
 	}
 	
+	/**
+	 * Refreshes the project.
+	 */
 	public void refresh() {
 		select();
         new ContextMenu("Refresh").select();
         new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 	}
 	
+	/**
+	 * Returns whether the project is selected.
+	 * 
+	 * @return whether the project is selected
+	 */
 	public boolean isSelected() {
 		return treeItem.isSelected();
 	}
 	
+	/**
+	 * Returns a project's child with a given text.
+	 * 
+	 * @param text Child's text
+	 * @return Child
+	 */
 	public ProjectItem getChild(String text) {
 		String[] childPath = new String[path.length + 1];
 		System.arraycopy(path, 0, childPath, 0, path.length);
@@ -75,14 +104,29 @@ public class ProjectItem {
 		return new ProjectItem(treeItem.getItem(text), project, childPath);
 	}
 	
+	/**
+	 * Returns a text of the project item.
+	 * 
+	 * @return Text
+	 */
 	public String getText() {
 		return treeItem.getText();
 	}
 	
+	/**
+	 * Returns a project of the project item.
+	 * 
+	 * @return Project of the project item
+	 */
 	public Project getProject() {
 		return project;
 	}
 	
+	/**
+	 * Returns list of children of the project item.
+	 * 
+	 * @return List of children of the project item
+	 */
 	public List<ProjectItem> getChildren() {
 		List<ProjectItem> childrens = new ArrayList<ProjectItem>();
 		for(TreeItem ti : treeItem.getItems()) {

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/j2ee/ui/project/facet/EarProjectFirstPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/j2ee/ui/project/facet/EarProjectFirstPage.java
@@ -14,60 +14,133 @@ import org.jboss.reddeer.swt.impl.table.DefaultTableItem;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 
+/**
+ * The first Wizard page for creating EAR project.
+ */
 public class EarProjectFirstPage extends WizardPage{
 	
+	/**
+	 * Sets a given project name.
+	 * 
+	 * @param projectName Project name
+	 */
 	public void setProjectName(String projectName){
 		new LabeledText("Project name:").setText(projectName);
 	}
 	
+	/**
+	 * Returns a project name.
+	 * 
+	 * @return Project name
+	 */
 	public String getProjectName(){
 		return new LabeledText("Project name:").getText();
 	}
 	
+	/**
+	 * Sets whether to use default location.
+	 * 
+	 * @param useDefaultLocation Indicates whether to use default location
+	 */
 	public void setUseDefaultLocation(boolean useDefaultLocation){
 		new CheckBox(new DefaultGroup("Project location"),"Use default location").toggle(useDefaultLocation);
 	}
 	
+	/**
+	 * Returns whether default locations is used.
+	 * 
+	 * @return Whether default locations is used
+	 */
 	public boolean isUseDefaultLocation(){
 		return new CheckBox(new DefaultGroup("Project location"),"Use default location").isChecked();
 	}
 	
+	/**
+	 * Sets a given location.
+	 * 
+	 * @param location Location
+	 */
 	public void setLocation(String location){
 		new LabeledText("Location:").setText(location);
 	}
 	
+	/**
+	 * Returns a location.
+	 * 
+	 * @return Location
+	 */
 	public String getLocation(){
 		return new LabeledText("Location:").getText();
 	}
 	
+	/**
+	 * Sets a given target runtime.
+	 * 
+	 * @param targetRuntime Target runtime
+	 */
 	public void setTargetRuntime(String targetRuntime){
 		new DefaultCombo(new DefaultGroup("Target runtime")).setSelection(targetRuntime);
 	}
 	
+	/**
+	 * Returns target runtime.
+	 * 
+	 * @return Target runtime
+	 */
 	public String getTargetRuntime(){
 		return new DefaultCombo(new DefaultGroup("Target runtime")).getSelection();
 	}
 	
+	/**
+	 * Sets EAR verion.
+	 * 
+	 * @param version EAR version
+	 */
 	public void setEARVersion(String version){
 		new DefaultCombo(new DefaultGroup("EAR version")).setSelection(version);
 	}
 	
+	/**
+	 * Returns EAR version.
+	 * 
+	 * @return EAR version
+	 */
 	public String getEARVersion(){
 		return new DefaultCombo(new DefaultGroup("EAR version")).getSelection();
 	}
 	
+	/**
+	 * Sets a given configuration.
+	 * 
+	 * @param configuration Configuration
+	 */
 	public void setConfiguration(String configuration){
 		new DefaultCombo(new DefaultGroup("Configuration")).setSelection(configuration);
 	}
 	
+	/**
+	 * Returns the selected configuration.
+	 * 
+	 * @return Selected configuration
+	 */
 	public String getConfiguration(){
 		return new DefaultCombo(new DefaultGroup("Configuration")).getSelection();
 	}
 	
+	/**
+	 * Sets whether to add project to working sets.
+	 * 
+	 * @param workingSets Whether to add project to working sets
+	 */
 	public void toggleWorkingSets(boolean workingSets){
 		new CheckBox(new DefaultGroup("Working sets"),"Add project to working sets").toggle(workingSets);
 	}
 	
+	/**
+	 * Sets a given list of working sets.
+	 * 
+	 * @param workingSets List of working sets
+	 */
 	public void setWorkingSets(List<String> workingSets){
 		new PushButton(new DefaultGroup("Working sets"), "Select...").click();
 		new DefaultShell("Select Working Sets");

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/j2ee/ui/project/facet/EarProjectInstallPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/j2ee/ui/project/facet/EarProjectInstallPage.java
@@ -12,22 +12,40 @@ import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.table.DefaultTable;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 
+/**
+ * The second wizard page for creating  EAR project.
+ */
 public class EarProjectInstallPage extends WizardPage{
 	
+	/**
+	 * Opens a wizard page for adding new module.
+	 * @return Wizard page for adding new module
+	 */
 	public NewJ2EEComponentSelectionPage newModule(){
 		new PushButton("New Module...").click();
 		new DefaultShell("Create default Java EE modules.");
 		return new NewJ2EEComponentSelectionPage();
 	}
 	
+	/**
+	 * Selects all.
+	 */
 	public void selectAll(){
 		new PushButton("Select All").click();
 	}
 	
+	/**
+	 * Deselects all.
+	 */
 	public void deselectAll(){
 		new PushButton("Deselect All").click();
 	}
 	
+	/**
+	 * Returns list of module dependencies.
+	 * 
+	 * @return List of module dependencies
+	 */
 	public List<String> getJavaEEModuleDependencies(){
 		List<String> modules = new ArrayList<String>();
 		for(TableItem i: new DefaultTable().getItems()){
@@ -36,22 +54,49 @@ public class EarProjectInstallPage extends WizardPage{
 		return modules;
 	}
 	
+	/**
+	 * Sets whether to select a given dependency.
+	 * 
+	 * @param dependency Dependency
+	 * @param toggle Whether to select the dependency
+	 */
 	public void toggleJavaEEModuleDependency(String dependency, boolean toggle){
 		new DefaultTable().getItem(dependency).setChecked(toggle);
 	}
 	
+	/**
+	 * Returns whether a given dependency is selected.
+	 * 
+	 * @param dependency Dependency
+	 * @return Whether the dependency is selected
+	 */
 	public boolean isJavaEEModuleDependency(String dependency){
 		return new DefaultTable().getItem(dependency).isChecked();
 	}
 	
+	/**
+	 * Sets a given content directory.
+	 * 
+	 * @param directory Content directory
+	 */
 	public void setContentDirectory(String directory){
 		new LabeledText("Content directory:").setText(directory);
 	}
 	
+	/**
+	 * Sets whether to generate application XML.
+	 * 
+	 * @param toggle Indicates whether to generate application XML
+	 */
 	public void toggleGenerateApplicationXML(boolean toggle){
 		new CheckBox("Generate application.xml deployment descriptor").toggle(toggle);
 	}
 	
+	/**
+	 * Returns whether application.xml is generated.
+	 * 
+	 * @return Whether application.xml is generated
+	 */
 	public boolean isGenerateApplicationXML(){
 		return new CheckBox("Generate application.xml deployment descriptor").isChecked();
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/j2ee/ui/project/facet/EarProjectWizard.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/j2ee/ui/project/facet/EarProjectWizard.java
@@ -2,11 +2,17 @@ package org.jboss.reddeer.eclipse.jst.j2ee.ui.project.facet;
 
 import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
 
+/**
+ * Wizard dialog for creating EAR project.
+ */
 public class EarProjectWizard extends NewWizardDialog{
 	
 	public static final String CATEGORY="Java EE";
 	public static final String NAME="Enterprise Application Project";
 	
+	/**
+	 * Constructs the wizard with {@value #CATEGORY}.
+	 */
 	public EarProjectWizard(){
 		super(CATEGORY,NAME);
 		addWizardPage(new EarProjectFirstPage(),0);

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/servlet/ui/WebProjectFirstPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/servlet/ui/WebProjectFirstPage.java
@@ -13,6 +13,9 @@ import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 
+/**
+ * The first wizard page for creating web project.
+ */
 public class WebProjectFirstPage extends WizardPage{
 	
 	public void setProjectName(String projectName){

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/servlet/ui/WebProjectSecondPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/servlet/ui/WebProjectSecondPage.java
@@ -13,6 +13,9 @@ import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
 
+/**
+ * The second wizard page for creating web project.
+ */
 public class WebProjectSecondPage extends WizardPage{
 	
 	public void editSourceFoldersOnBuildPath(String sourceFolder, String newVaule){

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/servlet/ui/WebProjectThirdPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/servlet/ui/WebProjectThirdPage.java
@@ -4,6 +4,9 @@ import org.jboss.reddeer.eclipse.jface.wizard.WizardPage;
 import org.jboss.reddeer.swt.impl.button.CheckBox;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 
+/**
+ * The third wizard page for creating web project.
+ */
 public class WebProjectThirdPage extends WizardPage{
 
 	public void setContextRoot(String contextRoot){

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/servlet/ui/WebProjectWizard.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jst/servlet/ui/WebProjectWizard.java
@@ -2,11 +2,17 @@ package org.jboss.reddeer.eclipse.jst.servlet.ui;
 
 import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
 
+/**
+ * Wizard dialog for creating web project.
+ */
 public class WebProjectWizard extends NewWizardDialog{
 	
 	public static final String CATEGORY="Web";
 	public static final String NAME="Dynamic Web Project";
 	
+	/**
+	 * Construct the wizard with {@value #CATEGORY} > {@value #NAME}.
+	 */
 	public WebProjectWizard(){
 		super(CATEGORY,NAME);
 		addWizardPage(new WebProjectFirstPage(), 0);

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/preferences/MavenPreferencePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/preferences/MavenPreferencePage.java
@@ -20,6 +20,9 @@ public class MavenPreferencePage extends WorkbenchPreferencePage {
 	private static final String UPDATE_MAVEN_PROJECTS_ON_STARTUP="Update Maven projects on startup";
 	private static final String HIDE_FOLDERS_OF_PHYSICALLY_NESTED_MODULES="Hide folders of physically nested modules (experimental)";
 
+	/**
+	 * Constructs the preference page with "Maven".
+	 */
 	public MavenPreferencePage() {
 		super("Maven");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/preferences/MavenSettingsPreferencePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/preferences/MavenSettingsPreferencePage.java
@@ -24,6 +24,9 @@ public class MavenSettingsPreferencePage extends WorkbenchPreferencePage {
 	private static final String UPDATE_SETTINGS = "Update Settings";
 	private static final String REINDEX = "Reindex";
 
+	/**
+	 * Construct the preference page with "Maven" > "User Settings".
+	 */
 	public MavenSettingsPreferencePage() {
 		super("Maven", "User Settings");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskList.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskList.java
@@ -10,61 +10,77 @@ import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 
-	/**
-	 * Represents a TaskList on {@link TaskListView}. 
-	 * 
-	 * @author ldimaggi
-	 * 
-	 */
-	public class TaskList {
+/**
+ * Represents a TaskList on {@link TaskListView}.
+ * 
+ * @author ldimaggi
+ * 
+ */
+public class TaskList {
 
-		private static final TimePeriod TIMEOUT = TimePeriod.VERY_LONG;
-		
-		protected final Logger log = Logger.getLogger(this.getClass());
-		
+	private static final TimePeriod TIMEOUT = TimePeriod.VERY_LONG;
+
+	protected final Logger log = Logger.getLogger(this.getClass());
+
+	private TreeItem treeItem;
+
+	public TaskList(TreeItem treeItem) {
+		this.treeItem = treeItem;
+	}
+
+	/**
+	 * Deletes the task list.
+	 */
+	public void delete() {
+		delete(false);
+	}
+
+	/**
+	 * Deletes the task list. The stop first option not yet implemented!
+	 * 
+	 * @param stopFirst Whether to stop first
+	 */
+	public void delete(boolean stopFirst) {
+		log.info("Deleting Repository");
+		select();
+		new ContextMenu("Delete").select();
+		new PushButton("OK").click();
+		new WaitUntil(new TreeItemIsDisposed(treeItem), TIMEOUT);
+		new WaitWhile(new JobIsRunning(), TIMEOUT);
+	}
+
+	/**
+	 * Selects the task list.
+	 */
+	protected void select() {
+		treeItem.select();
+	}
+
+	/**
+	 * Returns a name.
+	 * 
+	 * @return Name
+	 */
+	public String getName() {
+		return treeItem.getText();
+	}
+
+	private class TreeItemIsDisposed implements WaitCondition {
+
 		private TreeItem treeItem;
 
-		public TaskList(TreeItem treeItem) {
+		public TreeItemIsDisposed(TreeItem treeItem) {
 			this.treeItem = treeItem;
 		}
 
-		public void delete() {
-			delete(false);
+		@Override
+		public boolean test() {
+			return treeItem.isDisposed();
 		}
 
-		public void delete(boolean stopFirst) {
-			log.info("Deleting Repository");
-			select();
-			new ContextMenu("Delete").select();	
-			new PushButton("OK").click();
-			new WaitUntil(new TreeItemIsDisposed(treeItem), TIMEOUT);
-			new WaitWhile(new JobIsRunning(), TIMEOUT);
-		}
-
-		protected void select() {
-			treeItem.select();
-		}
-
-		public String getName(){
-			return treeItem.getText();
-		}
-
-		private class TreeItemIsDisposed implements WaitCondition {
-
-			private TreeItem treeItem;
-
-			public TreeItemIsDisposed(TreeItem treeItem) {
-				this.treeItem = treeItem;
-			}
-
-			@Override
-			public boolean test() {
-				return treeItem.isDisposed();
-			}
-
-			@Override
-			public String description() {
-				return "repository tree item is disposed";
-			}
+		@Override
+		public String description() {
+			return "repository tree item is disposed";
 		}
 	}
+}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskListView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskListView.java
@@ -26,10 +26,18 @@ public class TaskListView extends WorkbenchView {
 	
 	public static final String TITLE = "Task List";
 	
+	/**
+	 * Constructs the view with {@value #TITLE}.
+	 */
 	public TaskListView() {
 		super(TITLE);
 	}
 
+	/**
+	 * Returns list of task lists.
+	 * 
+	 * @return List of task lists
+	 */
 	public List<TaskList> getTaskLists(){
 		List<TaskList> theTaskLists = new ArrayList<TaskList>();
 
@@ -45,6 +53,12 @@ public class TaskListView extends WorkbenchView {
 		return theTaskLists;
 	}
 
+	/**
+	 * Returns a task list with a given name.
+	 * 
+	 * @param name Name
+	 * @return Task list
+	 */
 	public TaskList getTaskList(String name){
 		for (TaskList repository : getTaskLists()){
 			if (repository.getName().equals(name)){
@@ -59,7 +73,13 @@ public class TaskListView extends WorkbenchView {
 		return new DefaultTree();
 	}
 	
-	/* Method to locate and select a task in the task list view  */
+	/**
+	 * Returns a task with a given name and a category. The task is selected and returned as a tree item.
+	 * 
+	 * @param taskCategory Category
+	 * @param taskName Name
+	 * @return Task as a tree item
+	 */
 	public TreeItem getTask (String taskCategory, String taskName) {
 		new DefaultTree();
 		

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
@@ -28,15 +28,26 @@ public class TaskRepositoriesView extends WorkbenchView {
 	
 	public static final String TITLE = "Task Repositories";
 	
+	/**
+	 * Construct thw view with {@value #TITLE}.
+	 */
 	public TaskRepositoriesView() {
 		super(TITLE);
 	}
 
+	/**
+	 * Saves the task.
+	 */
 	public void saveTask () {
 		new ShellMenu("File", "Save").select(); 
 	}
 	
-	/* */
+	/**
+	 * Creates new local task.
+	 * 
+	 * @param repoItems
+	 * @param repoList
+	 */
 	public void createLocalTask (List<TreeItem> repoItems, ArrayList<String> repoList) {
 		
 		int elementIndex = repoList.indexOf("Local");
@@ -56,22 +67,38 @@ public class TaskRepositoriesView extends WorkbenchView {
 		new PushButton("Finish").click();	
 	}
 	
+	/**
+	 * Activates a task with a given name.
+	 * 
+	 * @param taskName Task name
+	 */
 	public void activateTask (String taskName) {
 		new ShellMenu("Navigate", "Activate Task...").select(); 
 		new DefaultText().setText(taskName);
 		new PushButton("OK").click();	
 	}
 	
+	/**
+	 * Opens a task with a given name.
+	 * 
+	 * @param taskName Task name
+	 */
 	public void openTask (String taskName) { 
 		new ShellMenu("Navigate", "Open Task...").select();    
 		new DefaultText().setText(taskName);
 		new PushButton("OK").click();	
 	}
 	
+	/**
+	 * Deactivates the task.
+	 */
 	public void deactivateTask () {
 		new ShellMenu("Navigate", "Deactivate Task").select();  
 	}
 	
+	/**
+	 * Deletes the task.
+	 */
 	public void deleteTask () {
 		new ShellMenu("Edit", "Delete").select();  
 		new PushButton("Yes").click();	

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/wizards/NewRepositoryWizard.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/wizards/NewRepositoryWizard.java
@@ -10,6 +10,9 @@ import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
  */
 public class NewRepositoryWizard extends NewWizardDialog {
 
+	/**
+	 * Construct the wizard with "General" > "File".
+	 */
 	public NewRepositoryWizard() {
 		super("General", "File");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/rse/ui/view/SystemView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/rse/ui/view/SystemView.java
@@ -25,6 +25,9 @@ public class SystemView extends WorkbenchView {
 	
 	private static final Logger log = Logger.getLogger(SystemView.class);
 	
+	/**
+	 * Constructs the view with {@value # TITLE}.
+	 */
 	public SystemView() {
 		super(TITLE);
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/rse/ui/wizard/NewConnectionWizardDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/rse/ui/wizard/NewConnectionWizardDialog.java
@@ -11,6 +11,9 @@ public class NewConnectionWizardDialog extends NewWizardDialog{
 	
 	public static final String TITLE = "New Connection";
 	
+	/**
+	 * Constructs the wizard with "Remote System Explorer" > {@value #TITLE}.
+	 */
 	public NewConnectionWizardDialog() {
 		super("Remote System Explorer", "Connection");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/rse/ui/wizard/SystemPasswordPromptDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/rse/ui/wizard/SystemPasswordPromptDialog.java
@@ -14,6 +14,9 @@ public class SystemPasswordPromptDialog {
 	
 	private Shell shell;
 	
+	/**
+	 * Constructs a dialog with {@value #TITLE}.
+	 */
 	public SystemPasswordPromptDialog() {
 		shell = new DefaultShell(TITLE);
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserEditor.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserEditor.java
@@ -9,16 +9,29 @@ import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 import org.jboss.reddeer.workbench.impl.editor.AbstractEditor;
 
+/**
+ * Represents a browser editor.
+ */
 public class BrowserEditor extends AbstractEditor{
 	
 	private InternalBrowser browser;
 	private static final TimePeriod TIMEOUT = TimePeriod.LONG;
 	
+	/**
+	 * Constructs the browser editor with a given title.
+	 * 
+	 * @param title Title
+	 */
 	public BrowserEditor(String title){
 		super(title);
 		browser = new InternalBrowser();
 	}
 	
+	/**
+	 * Constructs the browser editor with a given title matcher.
+	 * 
+	 * @param titleMatcher Title matcher
+	 */
 	public BrowserEditor(Matcher<String> titleMatcher){
 		super(titleMatcher);
 		browser = new InternalBrowser();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/console/ConsoleView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/console/ConsoleView.java
@@ -21,10 +21,18 @@ import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
  */
 public class ConsoleView extends WorkbenchView {
 
+	/**
+	 * Constructs the view with "Console".
+	 */
 	public ConsoleView() {
 		super("Console");
 	}
 	
+	/**
+	 * Returns console test.
+	 * 
+	 * @return Console text
+	 */
 	public String getConsoleText() {
 		new WaitUntil(new ConsoleHasTextWidget());
 		// wait for text to appear
@@ -32,6 +40,9 @@ public class ConsoleView extends WorkbenchView {
 		return new DefaultStyledText().getText();
 	}
 	
+	/**
+	 * Clears the console.
+	 */
 	public void clearConsole() {
 		log.info("Clearing console");
 		new DefaultToolItem("Clear Console").click();
@@ -39,12 +50,18 @@ public class ConsoleView extends WorkbenchView {
 		log.info("Console cleared");
 	}
 	
+	/**
+	 * Removes a launch from the console.
+	 */
 	public void removeLaunch() {
 		log.info("Removing launch from console");
 		new DefaultToolItem("Remove Launch").click();
 		log.info("Launch removed");
 	}
 	
+	/**
+	 * Removes all terminated launches.
+	 */
 	public void removeAllTerminatedLaunches() {
 		log.info("Removing terminated launches from console");
 		new DefaultToolItem("Remove All Terminated Launches").click();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/dialogs/PropertyPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/dialogs/PropertyPage.java
@@ -40,6 +40,11 @@ public abstract class PropertyPage extends PreferencePage {
 		t.select();
 	}
 	
+	/**
+	 * Returns page title.
+	 * 
+	 * @return Page title
+	 */
 	public String getPageTitle(){
 		return "Properties for " + getResourceName();
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/dialogs/WizardNewProjectCreationPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/dialogs/WizardNewProjectCreationPage.java
@@ -18,17 +18,32 @@ public class WizardNewProjectCreationPage extends WizardPage {
 	private final Logger log = Logger
 			.getLogger(WizardNewProjectCreationPage.class);
 
+	/**
+	 * Sets a given project name.
+	 * 
+	 * @param projectName Project name
+	 */
 	public void setProjectName(String projectName) {
 		log.debug("Set General Project name to " + projectName);
 		new LabeledText("Project name:").setText(projectName);
 	}
 
+	/**
+	 * Sets a given project location.
+	 * 
+	 * @param projectLocation Project location
+	 */
 	public void setProjectLocation(String projectLocation) {
 		log.debug("Set Project location to " + projectLocation);
 		new CheckBox("Use default location").toggle(false);
 		new LabeledText("Location:").setText(projectLocation);
 	}
 
+	/**
+	 * Adds a project to a given working set.
+	 * 
+	 * @param workingSet Working set
+	 */
 	public void addProjectToWorkingSet(String workingSet) {
 		log.debug("Add Project to working set" + workingSet);
 		new CheckBox("Add project to working sets").toggle(true);

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/dialogs/WizardNewProjectReferencePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/dialogs/WizardNewProjectReferencePage.java
@@ -16,6 +16,11 @@ public class WizardNewProjectReferencePage extends WizardPage {
 	private final Logger log = Logger
 			.getLogger(WizardNewProjectReferencePage.class);
 
+	/**
+	 * Sets a given project references.
+	 * 
+	 * @param referencedProjects Project references
+	 */
 	public void setProjectReferences(String... referencedProjects) {
 		log.debug("Set Project references to: ");
 		DefaultTable tbProjectReferences = new DefaultTable();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/NewFileCreationWizardDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/NewFileCreationWizardDialog.java
@@ -10,6 +10,9 @@ import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
  */
 public class NewFileCreationWizardDialog extends NewWizardDialog {
 
+	/**
+	 * Constructs the wizard with "General" > "File".
+	 */
 	public NewFileCreationWizardDialog() {
 		super("General", "File");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/NewFileCreationWizardPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/NewFileCreationWizardPage.java
@@ -29,10 +29,20 @@ public class NewFileCreationWizardPage extends WizardPage {
 		super();
 	}
 	
+	/**
+	 * Sets a given file name.
+	 * 
+	 * @param fileName File name
+	 */
 	public void setFileName(String fileName) {
 		new LabeledText("File name:").setText(fileName);
 	}
 	
+	/**
+	 * Sets a given folder path.
+	 * 
+	 * @param folderPath Folder path
+	 */
 	public void setFolderPath(String... folderPath) {
 		StringBuilder builder = new StringBuilder();
 		for (String pathElement : folderPath) {

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/QuickFixDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/ide/QuickFixDialog.java
@@ -22,7 +22,8 @@ public class QuickFixDialog extends DefaultShell {
 	public static final String TITLE = "Quick Fix";
 	
 	/**
-	 * Open QuickFix dialog and set focus on it
+	 * Constructs the view with {@value #TITLE}.
+	 * Opens QuickFix dialog and set focus on it.
 	 */
 	public QuickFixDialog() {
 		super(TITLE);

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/AbstractPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/AbstractPerspective.java
@@ -26,6 +26,11 @@ public abstract class AbstractPerspective {
   
   private String perspectiveLabel;
 
+  /**
+   * Constructs the perspective with a given label.
+   * 
+   * @param perspectiveLabel Perspective label
+   */
   public AbstractPerspective(String perspectiveLabel) {
     super();
     this.perspectiveLabel = perspectiveLabel;
@@ -34,6 +39,9 @@ public abstract class AbstractPerspective {
     }
   }
 
+  /**
+   * Opens the perspective
+   */
   public void open() {
     log.info("Open perspective: " + getPerspectiveLabel());
     if (isOpened()){
@@ -58,10 +66,20 @@ public abstract class AbstractPerspective {
     }
   }
 
+  /**
+   * Returns perspective label.
+   * 
+   * @return Perspective label
+   */
   public String getPerspectiveLabel() {
     return perspectiveLabel;
   }
   
+  /**
+   * Returns whether the perspective is open.
+   * 
+   * @return Whether the perspective is open
+   */
   	 public boolean isOpened(){
 		return Display.syncExec(new ResultRunnable<Boolean>() {
 			@Override

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/CVSRepositoryExploringPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/CVSRepositoryExploringPerspective.java
@@ -8,7 +8,7 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
 public class CVSRepositoryExploringPerspective extends AbstractPerspective {
 
 	/**
-	 * @param perspectiveLabel
+	 * Construct the perspective with "CVS Repository Exploring".
 	 */
 	public CVSRepositoryExploringPerspective() {
 		super("CVS Repository Exploring");

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/DatabaseDebugPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/DatabaseDebugPerspective.java
@@ -8,6 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class DatabaseDebugPerspective extends AbstractPerspective {
 
+	/**
+	 * Constructs the perspective with "Database Debug".
+	 */
 	public DatabaseDebugPerspective() {
 		super("Database Debug");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/DatabaseDevelopmentPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/DatabaseDevelopmentPerspective.java
@@ -8,6 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class DatabaseDevelopmentPerspective extends AbstractPerspective {
 
+	/**
+	 * Constructs the perspective with "Database Development".
+	 */
 	public DatabaseDevelopmentPerspective() {
 		super("Database Development");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/DebugPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/DebugPerspective.java
@@ -8,6 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class DebugPerspective extends AbstractPerspective {
 
+	/**
+	 * Constructs the perspective with "Debug".
+	 */
 	public DebugPerspective() {
 		super("Debug");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/GitRepositoryExploringPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/GitRepositoryExploringPerspective.java
@@ -8,6 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class GitRepositoryExploringPerspective extends AbstractPerspective {
 
+	/**
+	 * Constructs the perspective with "Git Repository Exploring".
+	 */
 	public GitRepositoryExploringPerspective() {
 		super("Git Repository Exploring");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JPAPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JPAPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class JPAPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "JPA".
+	 */
 	public JPAPerspective() {
 		super("JPA");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaBrowsingPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaBrowsingPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class JavaBrowsingPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "Java Browsing".
+	 */
 	public JavaBrowsingPerspective() {
 		super("Java Browsing");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaEEPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaEEPerspective.java
@@ -8,6 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class JavaEEPerspective extends AbstractPerspective {
 
+	/**
+	 * Constructs the perspective with "Java EE".
+	 */
 	public JavaEEPerspective() {
 		super("Java EE");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaPerspective.java
@@ -2,11 +2,16 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
 
 /**
  * Java Perspective implementation
+ * 
  * @author vlado pakan
  *
  */
-public class JavaPerspective extends AbstractPerspective{
-  public JavaPerspective(){
-    super ("Java");
-  }
+public class JavaPerspective extends AbstractPerspective {
+
+	/**
+	 * Constructs the perspective with "Java".
+	 */
+	public JavaPerspective() {
+		super("Java");
+	}
 }

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaScriptPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaScriptPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class JavaScriptPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "JavaScript".
+	 */
 	public JavaScriptPerspective() {
 		super("JavaScript");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaTypeHierarchyPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/JavaTypeHierarchyPerspective.java
@@ -9,6 +9,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
 
 public class JavaTypeHierarchyPerspective extends AbstractPerspective {
 
+	/**
+	 * Constructs the perspective with "Java Type Hierarchy".
+	 */
 	public JavaTypeHierarchyPerspective() {
 		super("Java Type Hierarchy");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/PlanningPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/PlanningPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class PlanningPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "Planning".
+	 */
 	public PlanningPerspective() {
 		super("Planning");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/PluginDevelopmentPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/PluginDevelopmentPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class PluginDevelopmentPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "Plug-in Development".
+	 */
 	public PluginDevelopmentPerspective() {
 		super("Plug-in Development");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/RemoteSystemExplorerPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/RemoteSystemExplorerPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class RemoteSystemExplorerPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "Remote System Explorer".
+	 */
 	public RemoteSystemExplorerPerspective() {
 		super("Remote System Explorer");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/ResourcePerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/ResourcePerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class ResourcePerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "Resource".
+	 */
 	public ResourcePerspective() {
 		super("Resource");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/TeamSynchronizingPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/TeamSynchronizingPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class TeamSynchronizingPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "Team Synchronizing".
+	 */
 	public TeamSynchronizingPerspective() {
 		super("Team Synchronizing");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/WebPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/WebPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class WebPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "Web".
+	 */
 	public WebPerspective() {
 		super("Web");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/XMLPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/XMLPerspective.java
@@ -8,7 +8,9 @@ package org.jboss.reddeer.eclipse.ui.perspectives;
  */
 public class XMLPerspective extends AbstractPerspective {
 
-
+	/**
+	 * Constructs the perspective with "XML".
+	 */
 	public XMLPerspective() {
 		super("XML");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/problems/ProblemsView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/problems/ProblemsView.java
@@ -13,6 +13,9 @@ import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
  */
 public class ProblemsView extends WorkbenchView{
 
+	/**
+	 * Constructs the view with "Problems".
+	 */
 	public ProblemsView() {
 		super("Problems");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/contentoutline/OutlineView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/contentoutline/OutlineView.java
@@ -17,38 +17,67 @@ import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
  */
 public class OutlineView extends WorkbenchView {
 
+	/**
+	 * Construct the view with "Outline".
+	 */
 	public OutlineView() {
 		super("Outline");
 	}
 
+	/**
+	 * Returns collection of outline elements.
+	 * 
+	 * @return Collection of outline elements
+	 */
 	public Collection<TreeItem> outlineElements() {
 		return getTreeForView();
 	}
 
+	/**
+	 * Clicks on tooltip "Collapse All".
+	 */
 	public void collapseAll() {
 		clickOnToolTip("Collapse All.*");
 	}
-	
+
+	/**
+	 * Clicks on tooltip "Sort".
+	 */
 	public void sort() {
 		clickOnToolTip("Sort.*");
 	}
 	
+	/**
+	 * Clicks on tooltip "Hide Fields".
+	 */
 	public void hideFields() {
 		clickOnToolTip("Hide Fields.*");
 	}
-	
+
+	/**
+	 * Clicks on tooltip "Hide Static Fields and Methods".
+	 */
 	public void hideStaticFieldsAndMethods() {
 		clickOnToolTip("Hide Static Fields and Methods.*");
 	}
-	
+
+	/**
+	 * Clicks on tooltip "Hide Non-Public Members".
+	 */
 	public void hideNonPublicMembers() {
 		clickOnToolTip("Hide Non-Public Members.*");
 	}
-	
+
+	/**
+	 * Clicks on tooltip "Hide Local Types".
+	 */
 	public void hideLocalTypes() {
 		clickOnToolTip("Hide Local Types.*");
 	}
-	
+
+	/**
+	 * Clicks on tooltip "Link with Editor".
+	 */
 	public void linkWithEditor() {
 		clickOnToolTip("Link with Editor.*");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogMessage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogMessage.java
@@ -26,23 +26,47 @@ public class LogMessage {
 		this.severity = severity;
 	}
 	
+	/**
+	 * Returns a severity.
+	 * 
+	 * @return severity
+	 */
 	public int getSeverity() {
 		return severity;
 	}
 	
+	/**
+	 * Returns a message.
+	 * 
+	 * @return Message
+	 */
 	public String getMessage() {
 		return treeItem.getCell(0);
 	}
 
+	/**
+	 * Returns a plugin.
+	 * 
+	 * @return Plugin
+	 */
 	public String getPlugin() {
 		return treeItem.getCell(1);
 	}
 
-
+	/**
+	 * Returns the date.
+	 * 
+	 * @return Date
+	 */
 	public String getDate() {
 		return treeItem.getCell(2);
 	}
 	
+	/**
+	 * Returns a stack trace.
+	 * 
+	 * @return Stack trace
+	 */
 	public String getStackTrace(){
 		treeItem.select();
 		new ContextMenu("Event Details").select();
@@ -52,6 +76,11 @@ public class LogMessage {
 		return stackTrace;
 	}
 	
+	/**
+	 * Returns session data.
+	 * 
+	 * @return Session data
+	 */
 	public String getSessionData(){
 		treeItem.select();
 		new ContextMenu("Event Details").select();
@@ -61,6 +90,11 @@ public class LogMessage {
 		return sessionData;
 	}
 	
+	/**
+	 * Returns sublog messages.
+	 * 
+	 * @return Sublog messages
+	 */
 	public List<LogMessage> getSubLogMessages(){
 		List<LogMessage> lm = new ArrayList<LogMessage>();
 		for(TreeItem i: treeItem.getItems()){

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogView.java
@@ -37,6 +37,9 @@ public class LogView extends WorkbenchView{
 	public static final String WARNING_SEVERITY="Warning";
 	public static final String ERROR_SEVERITY="Error";
 	
+	/**
+	 * Constructs the view with "Error Log".
+	 */
 	public LogView(){
 		super("Error Log");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/navigator/ResourceNavigator.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/navigator/ResourceNavigator.java
@@ -11,6 +11,10 @@ import org.jboss.reddeer.eclipse.jdt.ui.AbstractExplorer;
  *
  */
 public class ResourceNavigator extends AbstractExplorer {
+	
+	/**
+	 * Construct the explorer with "Navigator". 
+	 */
 	public ResourceNavigator() {
 		super("Navigator");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/properties/PropertiesView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/properties/PropertiesView.java
@@ -14,6 +14,10 @@ import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
  *
  */
 public class PropertiesView extends WorkbenchView{
+	
+	/**
+	 * Constructs the view with "Properties".
+	 */
 	public PropertiesView() {
 		super("Properties");
 	}
@@ -21,7 +25,7 @@ public class PropertiesView extends WorkbenchView{
 	/**
 	 * Returns list of Properties
 	 * 
-	 * @return
+	 * @return list of Properties
 	 */
 	public List<PropertiesViewProperty> getProperties(){
 		open();
@@ -31,20 +35,35 @@ public class PropertiesView extends WorkbenchView{
 		}
 		return properties;
 	}
+	
 	/**
 	 * Returns ViewProperty with propertyName
-	 * @param propertyName
-	 * @return
+	 * 
+	 * @param propertyName Property name
+	 * @return ViewProperty with propertyName
 	 */
 	public PropertiesViewProperty getProperty(String... propertyNamePath){
 		open();
 		return new PropertiesViewProperty(new DefaultTreeItem(propertyNamePath));
 	}
+	
+	/**
+	 * Sets whether to show categories.
+	 * 
+	 * @param toggle Indicates whether to show categories
+	 */
 	public void toggleShowCategories(boolean toggle){
 		open();
 		new DefaultToolItem("Show Categories")
 			.toggle(toggle);
 	}
+
+
+	/**
+	 * Sets whether to show advanced properties.
+	 * 
+	 * @param toggle Indicates whether to show advanced properties
+	 */
 	public void toggleShowAdvancedProperties(boolean toggle){
 		open();
 		new DefaultToolItem("Show Advanced Properties")

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/wizards/datatransfer/ExternalProjectImportWizardDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/wizards/datatransfer/ExternalProjectImportWizardDialog.java
@@ -10,6 +10,9 @@ import org.jboss.reddeer.eclipse.jface.wizard.ImportWizardDialog;
  */
 public class ExternalProjectImportWizardDialog extends ImportWizardDialog {
 
+	/**
+	 * Construct the wizard with "General" > "Existing Projects into Workspace".
+	 */
 	public ExternalProjectImportWizardDialog() {
 		super(new String[]{"General", "Existing Projects into Workspace"});
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/wizards/datatransfer/WizardProjectsImportPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/wizards/datatransfer/WizardProjectsImportPage.java
@@ -45,6 +45,9 @@ public class WizardProjectsImportPage extends WizardPage {
 		super();
 	}
 	
+	/**
+	 * Represents an imported project.
+	 */
 	public static class ImportProject {
 		
 		public boolean isChecked;
@@ -57,16 +60,31 @@ public class WizardProjectsImportPage extends WizardPage {
 		}
 	}
 
+	/**
+	 * Sets root directory.
+	 * 
+	 * @param directory Root directory
+	 */
 	public void setRootDirectory(String directory){
 		log.info("Setting root directory to " + directory);
 		setPath("Select root directory:", directory);
 	}
 	
+	/**
+	 * Sets archive file.
+	 * 
+	 * @param file File
+	 */
 	public void setArchiveFile(String file){
 		log.info("Settig archive file to " + file);
 		setPath("Select archive file:", file);
 	}
 
+	/**
+	 * Sets whether to copy projects into workspace.
+	 * 
+	 * @param copy Indicates whether to copy projects into workspace
+	 */
 	public void copyProjectsIntoWorkspace(boolean copy){
 		log.info("Setting copy checkbox to " + copy);
 		if (isFileSystem()){
@@ -76,6 +94,11 @@ public class WizardProjectsImportPage extends WizardPage {
 		}
 	}
 	
+	/**
+	 * Returns list of projects.
+	 * 
+	 * @return List of projects
+	 */
 	public List<ImportProject> getProjects(){
 		List<ImportProject> projects = new ArrayList<ImportProject>();
 		
@@ -90,6 +113,11 @@ public class WizardProjectsImportPage extends WizardPage {
 		return projects;
 	}
 	
+	/**
+	 * Selects a given projects.
+	 * 
+	 * @param projects Projects
+	 */
 	public void selectProjects(String... projects){
 		log.info("Selecting projects");
 		deselectAllProjects();
@@ -101,11 +129,17 @@ public class WizardProjectsImportPage extends WizardPage {
 		}
 	}
 	
+	/**
+	 * Selects all projects.
+	 */
 	public void selectAllProjects(){
 		log.info("Selecting all projects");
 		new PushButton("Select All").click();
 	}
 	
+	/**
+	 * Deselects all projects.
+	 */
 	public void deselectAllProjects(){
 		log.info("Deselecting all projects");
 		new PushButton("Deselect All").click();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/wizards/newresource/BasicNewProjectResourceWizard.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/wizards/newresource/BasicNewProjectResourceWizard.java
@@ -12,6 +12,9 @@ import org.jboss.reddeer.eclipse.ui.dialogs.WizardNewProjectReferencePage;
  */
 public class BasicNewProjectResourceWizard extends NewWizardDialog {
 	
+	/**
+	 * Constructs the wizard with "General" > "Project".
+	 */
 	public BasicNewProjectResourceWizard() {
 		super("General", "Project");
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/common/project/facet/ui/RuntimesPropertyPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/common/project/facet/ui/RuntimesPropertyPage.java
@@ -20,6 +20,11 @@ public class RuntimesPropertyPage extends ProjectPropertyPage {
 
 	public static final String NAME = "Targeted Runtimes"; 
 	
+	/**
+	 * Constructs the property page with a given project and {@value #NAME}.
+	 * 
+	 * @param project Project name
+	 */
 	public RuntimesPropertyPage(Project project) {
 		super(project, NAME);
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/RuntimePreferencePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/RuntimePreferencePage.java
@@ -24,10 +24,18 @@ public class RuntimePreferencePage extends WorkbenchPreferencePage {
 
 	private static final Logger log = Logger.getLogger(RuntimePreferencePage.class);
 	
+	/**
+	 * Constructs the preference page with "Server" > {@value #PAGE_NAME}.
+	 */
 	public RuntimePreferencePage() {
 		super("Server", PAGE_NAME);
 	}
 	
+	/**
+	 * Return list of server runtimes.
+	 * 
+	 * @return List of server runtimes
+	 */
 	public List<Runtime> getServerRuntimes(){
 		List<Runtime> runtimes = new ArrayList<Runtime>();
 		
@@ -43,6 +51,11 @@ public class RuntimePreferencePage extends WorkbenchPreferencePage {
 		return runtimes;
 	}
 	
+	/**
+	 * Removes a given runtime.
+	 * 
+	 * @param runtime Runtime
+	 */
 	public void removeRuntime(Runtime runtime){
 		log.info("Removing runtime " + runtime);
 		selectRuntime(runtime.getName());
@@ -52,6 +65,9 @@ public class RuntimePreferencePage extends WorkbenchPreferencePage {
 		}
 	}
 	
+	/**
+	 * Removes all runtimes.
+	 */
 	public void removeAllRuntimes(){
 		log.info("Removing all runtimes");
 		for (Runtime runtime : getServerRuntimes()){
@@ -70,6 +86,11 @@ public class RuntimePreferencePage extends WorkbenchPreferencePage {
 		}
 	}
 	
+	/**
+	 * Opens a wizard for adding new runtime.
+	 * 
+	 * @return Wizard for adding new runtime
+	 */
 	public NewRuntimeWizardDialog addRuntime(){
 		log.info("Adding new runtime");
 		new PushButton("Add...").click();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/AbstractLabel.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/AbstractLabel.java
@@ -95,14 +95,29 @@ public abstract class AbstractLabel {
 		return styles[0];
 	}
 
+	/**
+	 * Returns a server name.
+	 * 
+	 * @return Server name
+	 */
 	public String getName() {
 		return name;
 	}
 	
+	/**
+	 * Returns a server state.
+	 * 
+	 * @return Server state
+	 */
 	public ServerState getState() {
 		return state;
 	}
 	
+	/**
+	 * Returns a server publish state.
+	 * 
+	 * @return Server publish state
+	 */
 	public ServerPublishState getPublishState() {
 		return status;
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/Server.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/Server.java
@@ -48,10 +48,20 @@ public class Server {
 		this.treeItem = treeItem;
 	}
 
+	/**
+	 * Returns a server label.
+	 * 
+	 * @return Server label
+	 */
 	public ServerLabel getLabel(){
 		return new ServerLabel(treeItem);
 	}
 
+	/**
+	 * Returns list of modules.
+	 * 
+	 * @return List of modules
+	 */
 	public List<ServerModule> getModules() {
 		final List<ServerModule> modules = new ArrayList<ServerModule>();
 
@@ -72,6 +82,12 @@ public class Server {
 		return modules;
 	}
 
+	/**
+	 * Return a module with a given name.
+	 * 
+	 * @param name Module name
+	 * @return Module
+	 */
 	public ServerModule getModule(String name) {
 		for (ServerModule module : getModules()){
 			if (module.getLabel().getName().equals(name)){
@@ -81,18 +97,31 @@ public class Server {
 		throw new EclipseLayerException("There is no module with name " + name + " on server " + getLabel().getName());
 	}
 
+	/**
+	 * Opens a dialog for adding/removing modules.
+	 * 
+	 * @return Dialog for adding/removing modules
+	 */
 	public ModifyModulesDialog addAndRemoveModules() {
 		select();
 		new ContextMenu(ADD_AND_REMOVE).select();
 		return new ModifyModulesDialog();
 	}
 	
+	/**
+	 * Opens the server editor.
+	 * 
+	 * @return Server editor
+	 */
 	public ServerEditor open() {
 		select();
 		new ContextMenu("Open").select();
 		return createServerEditor(getLabel().getName());
 	}
 
+	/**
+	 * Starts the server.
+	 */
 	public void start() {
 		log.info("Starting server " + getLabel().getName());
 		if (!ServerState.STOPPED.equals(getLabel().getState())){
@@ -101,6 +130,9 @@ public class Server {
 		operateServerState("Start", ServerState.STARTED);
 	}
 
+	/**
+	 * Debugs the server.
+	 */
 	public void debug() {
 		log.info("Starting server in debug" + getLabel().getName());
 		if (!ServerState.STOPPED.equals(getLabel().getState())){
@@ -109,6 +141,9 @@ public class Server {
 		operateServerState("Debug", ServerState.DEBUGGING);
 	}
 
+	/**
+	 * Profiles the server.
+	 */
 	public void profile() {
 		log.info("Starting server in profiling mode" + getLabel().getName());
 		if (!ServerState.STOPPED.equals(getLabel().getState())){
@@ -117,6 +152,9 @@ public class Server {
 		operateServerState("Profile", ServerState.PROFILING);
 	}
 
+	/**
+	 * Restarts the server.
+	 */
 	public void restart() {
 		log.info("Restarting server " + getLabel().getName());
 		if (!getLabel().getState().isRunningState()){
@@ -125,6 +163,9 @@ public class Server {
 		operateServerState("Restart", ServerState.STARTED);
 	}
 
+	/**
+	 * Restarts the server in debug.
+	 */
 	public void restartInDebug() {
 		log.info("Restarting server in debug" + getLabel().getName());
 		if (!getLabel().getState().isRunningState()){
@@ -133,6 +174,9 @@ public class Server {
 		operateServerState("Restart in Debug", ServerState.DEBUGGING);
 	}
 
+	/**
+	 * Restarts the server in profile.
+	 */
 	public void restartInProfile() {
 		log.info("Restarting server in profile" + getLabel().getName());
 		if (!getLabel().getState().isRunningState()){
@@ -141,6 +185,9 @@ public class Server {
 		operateServerState("Restart in Profile", ServerState.PROFILING);
 	}
 
+	/**
+	 * Stops the server.
+	 */
 	public void stop() {
 		log.info("Stopping server " + getLabel().getName());
 		ServerState state = getLabel().getState();
@@ -150,6 +197,9 @@ public class Server {
 		operateServerState("Stop", ServerState.STOPPED);
 	}
 
+	/**
+	 * Publishes the server.
+	 */
 	public void publish() {
 		log.info("Publishing server " + getLabel().getName());
 		select();
@@ -157,6 +207,9 @@ public class Server {
 		waitForPublish();
 	}
 
+	/**
+	 * Cleans the server.
+	 */
 	public void clean() {
 		log.info("Cleaning server " + getLabel().getName());
 		select();
@@ -166,10 +219,18 @@ public class Server {
 		waitForPublish();
 	}
 
+	/**
+	 * Deletes the server. The server is not stop first.
+	 */
 	public void delete() {
 		delete(false);
 	}
 
+	/**
+	 * Deletes the server. You can specify whether the server is stop first.
+	 * 
+	 * @param stopFirst Indicates whether the server is stop first.
+	 */
 	public void delete(boolean stopFirst) {
 		final String name = getLabel().getName();
 		log.info("Deleting server " + name + ". Stopping server first: " + stopFirst);
@@ -186,6 +247,9 @@ public class Server {
 		new WaitWhile(new JobIsRunning(), TIMEOUT);
 	}
 
+	/**
+	 * Selects the server.
+	 */
 	protected void select() {
 		treeItem.select();
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/ServerModule.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/ServerModule.java
@@ -20,6 +20,9 @@ public class ServerModule {
 		return new ModuleLabel(treeItem);
 	}
 	
+	/**
+	 * Removes the server module. Not yet implemented!
+	 */
 	public void remove(){
 		throw new UnsupportedOperationException();
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/ServersView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/ServersView.java
@@ -27,10 +27,18 @@ public class ServersView extends WorkbenchView {
 
 	private static final Logger log = Logger.getLogger(ServersView.class);
 
+	/**
+	 * Constructs the view with {@value #TITLE}.
+	 */
 	public ServersView() {
 		super(TITLE);
 	}
 
+	/**
+	 * Opens a wizard for adding new server.
+	 * 
+	 * @return Wizard for adding new server
+	 */
 	public NewServerWizardDialog newServer(){
 		log.info("Creating new server");
 		open();
@@ -39,6 +47,11 @@ public class ServersView extends WorkbenchView {
 		return new NewServerWizardDialog();
 	}
 
+	/**
+	 * Returns list of servers.
+	 * 
+	 * @return List of servers
+	 */
 	public List<Server> getServers(){
 		List<Server> servers = new ArrayList<Server>();
 
@@ -54,6 +67,12 @@ public class ServersView extends WorkbenchView {
 		return servers;
 	}
 
+	/**
+	 * Returns a server with a given name.
+	 * 
+	 * @param name Server name
+	 * @return Server with a given name.
+	 */
 	public Server getServer(String name){
 		for (Server server : getServers()){
 			if (server.getLabel().getName().equals(name)){


### PR DESCRIPTION
Review and update missing javadoc

all public members (classes, methods, etc.) should contains javadoc
user should be able able to understand behaviour from description without analyzing the code
use since (for example since 0.5 means <0.5-snapshot...0.6)
use deprecated with referencing the replacement
