### PR TITLE
New customArgLine property for custom surefire parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 		<eclipse-target-site>http://download.eclipse.org/releases/luna</eclipse-target-site>
 		<swtbot-update-site>http://download.eclipse.org/technology/swtbot/releases/2.2.1</swtbot-update-site>
 		<platformSystemProperties></platformSystemProperties>
+		<customArgLine></customArgLine>
 		<logDebug>true</logDebug>
 		<pauseFailedTest>false</pauseFailedTest>
 		<recordScreenCast>false</recordScreenCast>
@@ -99,7 +100,7 @@
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
 					<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
-					<argLine>-DlogDebug=${log.debug} -DpauseFailedTest=${pauseFailedTest} -DrecordScreenCast=${recordScreenCast} -DrelativeScreenshotDirectory=${relativeScreenshotDirectory} ${platformSystemProperties} -XX:MaxPermSize=512m</argLine>
+					<argLine>-DlogDebug=${log.debug} -DpauseFailedTest=${pauseFailedTest} -DrecordScreenCast=${recordScreenCast} -DrelativeScreenshotDirectory=${relativeScreenshotDirectory} ${platformSystemProperties} ${customArgLine} -XX:MaxPermSize=512m -Xmx512m</argLine>
 					<product>org.eclipse.platform.ide</product>
 					<application>org.eclipse.ui.ide.workbench</application>
 					<dependencies>

--- a/tests/org.jboss.reddeer.requirements.test/pom.xml
+++ b/tests/org.jboss.reddeer.requirements.test/pom.xml
@@ -14,6 +14,7 @@
 	
 	<properties>
 		<apache-tomcat-7.home>${project.build.directory}/apache-tomcat-7.0.54</apache-tomcat-7.home>
+		<customArgLine>-Dreddeer.config=${basedir}/bin</customArgLine>
 	</properties>
 
 	<profiles>
@@ -61,7 +62,6 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
 					<useUIThread>false</useUIThread>
-					<argLine>-Xms256m -Xmx512m -XX:PermSize=64m -XX:MaxPermSize=128m -Dreddeer.config=${basedir}/bin</argLine>
 					<dependencies combine.children="append">
 								<!-- This entry should enable creating of default JDK on Mac -->
 								<dependency>


### PR DESCRIPTION
There is now a new empty property, that you can override in your test pom, to
get some custom args into surefire's argLine.
