### PR TITLE
Replace references to RedDeerSchema.xsd from cloud.github.com to jboss.org

### DIFF
--- a/plugins/org.jboss.reddeer.requirements/resources/ServerRequirementsBase.xsd
+++ b/plugins/org.jboss.reddeer.requirements/resources/ServerRequirementsBase.xsd
@@ -5,7 +5,7 @@
 
 	<!-- Import basic RedDeer requirements -->
 	<xs:import namespace="http://www.jboss.org/NS/Req"
-		schemaLocation="http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd" />
+		schemaLocation="http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd" />
 
 	<!-- Specify user-requirement -->
 	<xs:element name="server-requirement" type="server:serverRequirementType"

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/configuration/JavaRequirements.xsd
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/configuration/JavaRequirements.xsd
@@ -7,7 +7,7 @@
         xmlns:rd="http://www.jboss.org/NS/Req">
         
         <!-- Import basic RedDeer requirements -->
-        <xs:import namespace="http://www.jboss.org/NS/Req" schemaLocation="http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd" />
+        <xs:import namespace="http://www.jboss.org/NS/Req" schemaLocation="http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd" />
 
         <!-- Specify user-requirement -->
         <xs:element name="java-requirement" type="java:javaRequirementType" substitutionGroup="rd:abstractRequirement">

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/configuration/requirementsA.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/configuration/requirementsA.xml
@@ -3,7 +3,7 @@
 	xmlns="http://www.jboss.org/NS/Req" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:java="http://www.jboss.org/NS/JavaReq"
-	xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd">
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd">
 
 	<requirements>
 	

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/configuration/requirementsB.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/configuration/requirementsB.xml
@@ -3,7 +3,7 @@
 	xmlns="http://www.jboss.org/NS/Req" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:java="http://www.jboss.org/NS/JavaReq"
-	xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd">
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd">
 
 	<requirements>
 	

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/runner/order/fileA.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/runner/order/fileA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testrun xmlns="http://www.jboss.org/NS/Req" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd"
 	xmlns:java="http://www.jboss.org/NS/JavaReq">
 
 	<requirements>

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/runner/order/fileB.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/integration/runner/order/fileB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testrun xmlns="http://www.jboss.org/NS/Req" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd"
 	xmlns:java="http://www.jboss.org/NS/JavaReq">
 
 	<requirements>

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/namespace.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/namespace.xml
@@ -1,6 +1,6 @@
 <testrun xmlns="http://www.jboss.org/NS/Req" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:user="http://www.jboss.org/NS/user-schema"
-	xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/user-schema user-schema.xsd">
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/user-schema user-schema.xsd">
 
 	<requirements>
 		<requirement

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/nocustomschema.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/nocustomschema.xml
@@ -3,7 +3,7 @@
         xmlns="http://www.jboss.org/NS/Req" 
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:user="http://www.jboss.org/NS/user-schema"
-        xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd">
+        xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd">
 
         <requirements>
                 <user:user-requirement name="user-requirement">

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/nonvalid.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/nonvalid.xml
@@ -3,7 +3,7 @@
         xmlns="http://www.jboss.org/NS/Req" 
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:user="http://www.jboss.org/NS/user-schema"
-        xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/user-schema user-schema.xsd">
+        xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/user-schema user-schema.xsd">
 
         <requirements>
                 <user:user-requirement name="user-requirement">

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/simple.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/simple.xml
@@ -1,5 +1,5 @@
 <testrun xmlns="http://www.jboss.org/NS/Req" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd">
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd">
 
 	<requirements>
 		<requirement name="userRequirement1"

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/user-schema.xsd
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/user-schema.xsd
@@ -7,7 +7,7 @@
         xmlns:rd="http://www.jboss.org/NS/Req">
         
         <!-- Import basic RedDeer requirements -->
-        <xs:import namespace="http://www.jboss.org/NS/Req" schemaLocation="http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd" />
+        <xs:import namespace="http://www.jboss.org/NS/Req" schemaLocation="http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd" />
 
         <!-- Specify user-requirement -->
         <xs:element name="user-requirement" type="user:userRequirementType" substitutionGroup="rd:abstractRequirement">

--- a/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/valid.xml
+++ b/tests/org.jboss.reddeer.junit.test/src/test/resources/org/jboss/reddeer/junit/internal/configuration/reader/valid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testrun xmlns="http://www.jboss.org/NS/Req" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:user="http://www.jboss.org/NS/user-schema"
-	xsi:schemaLocation="http://www.jboss.org/NS/Req http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/user-schema user-schema.xsd">
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd http://www.jboss.org/NS/user-schema user-schema.xsd">
 
 	<requirements>
 		<user:user-requirement name="user-requirement">


### PR DESCRIPTION
We shouldn't use http://cloud.github.com/downloads/jboss-reddeer/reddeer/RedDeerSchema.xsd and instead of this we should use http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd
