### PR TITLE
Refector Matchers

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/AbstractPerspective.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/perspectives/AbstractPerspective.java
@@ -10,7 +10,8 @@ import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.table.DefaultTable;
-import org.jboss.reddeer.swt.matcher.WithRegexMatchers;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
+import org.jboss.reddeer.swt.matcher.WithTextMatchers;
 import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 
@@ -49,8 +50,10 @@ public abstract class AbstractPerspective {
     }
     else{
       log.debug("Trying to open perspective: " + getPerspectiveLabel());
-      WithRegexMatchers m = new WithRegexMatchers("Window.*", "Open Perspective.*",
-          "Other...*");
+      WithTextMatchers m = new WithTextMatchers(new RegexMatcher[] {
+					new RegexMatcher("Window.*"),
+					new RegexMatcher("Open Perspective.*"),
+					new RegexMatcher("Other...*") });
       Menu menu = new ShellMenu(m.getMatchers());
       menu.select();
       new DefaultShell("Open Perspective");

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/contentoutline/OutlineView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/contentoutline/OutlineView.java
@@ -7,7 +7,8 @@ import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
-import org.jboss.reddeer.swt.matcher.WithRegexMatcher;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
+import org.jboss.reddeer.swt.matcher.WithTextMatcher;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 /**
  * Represents Outline view in Eclipse
@@ -93,7 +94,7 @@ public class OutlineView extends WorkbenchView {
 	}
 	
 	private void clickOnToolTip(String regex) {
-		WithRegexMatcher rm = new WithRegexMatcher(regex);
+		WithTextMatcher rm = new WithTextMatcher(new RegexMatcher(regex));
 		new DefaultToolItem(rm).click();
 	}
 	

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/condition/ShellWithTextIsAvailable.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/condition/ShellWithTextIsAvailable.java
@@ -2,10 +2,9 @@ package org.jboss.reddeer.swt.condition;
 
 import org.eclipse.swt.widgets.Shell;
 import org.hamcrest.Matcher;
-import org.hamcrest.core.IsEqual;
 import org.jboss.reddeer.junit.logging.Logger;
 import org.jboss.reddeer.swt.lookup.ShellLookup;
-import org.jboss.reddeer.swt.matcher.ObjectToStingMatcherDecorator;
+import org.jboss.reddeer.swt.matcher.WithTextMatcher;
 import org.jboss.reddeer.swt.util.internal.InstanceValidator;
 
 /**
@@ -15,8 +14,7 @@ import org.jboss.reddeer.swt.util.internal.InstanceValidator;
  * @author jniederm
  * 
  */
-public class ShellWithTextIsAvailable implements WaitCondition {
-
+public class ShellWithTextIsAvailable implements WaitCondition { 
 	private Matcher<String> matcher;
 	private final Logger log = Logger.getLogger(this.getClass());
 	
@@ -25,21 +23,8 @@ public class ShellWithTextIsAvailable implements WaitCondition {
 	 */
 	public ShellWithTextIsAvailable(String title) {
 		InstanceValidator.checkNotNull(title, "title");
-		this.matcher = wrapStringMatcher(new IsEqual<String>(title));
+		this.matcher = new WithTextMatcher(title);
 	}
-
-	/**
-	 * @throws IllegalArgumentException if {@code matcher} is {@code null}
-	 */
-	public ShellWithTextIsAvailable(Matcher<String> matcher) {
-		InstanceValidator.checkNotNull(matcher, "matcher");
-		this.matcher = wrapStringMatcher(matcher);
-	}
-	
-	private static Matcher<String> wrapStringMatcher(final Matcher<String> innerMatcher) {
-		return new ObjectToStingMatcherDecorator(innerMatcher);
-	}
-
 
 	@Override
 	public boolean test() {

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/LinkTextMatcher.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/LinkTextMatcher.java
@@ -2,6 +2,7 @@ package org.jboss.reddeer.swt.matcher;
 
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Widget;
+import org.hamcrest.Matcher;
 import org.jboss.reddeer.swt.handler.LinkHandler;
 
 /**
@@ -14,10 +15,24 @@ import org.jboss.reddeer.swt.handler.LinkHandler;
 public class LinkTextMatcher extends WithTextMatcher {
 	
 
+	/**
+	 * Matches link with given text.
+	 * @param text Text to match.
+	 */
+	
 	public LinkTextMatcher(String text) {
 		super(text);
 	}
 
+	/**
+	 * Matches link with given matcher.
+	 * @param matcher Matcher to use against link text.
+	 */
+	
+	public LinkTextMatcher(Matcher<String> matcher) {
+		super(matcher);
+	}
+	
 	@Override
 	protected String extractWidgetText(Widget widget) {
 		if (widget instanceof Link){

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/ObjectToStingMatcherDecorator.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/ObjectToStingMatcherDecorator.java
@@ -11,6 +11,7 @@ import org.jboss.reddeer.swt.handler.WidgetHandler;
  * It allows string matchers to be used on {@link String}s and {@link Widget}s in uniform way.
  * 
  * @author jniederm
+ * @deprecated in 0.6
  */
 public class ObjectToStingMatcherDecorator extends BaseMatcher<String> {
 	

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/RegexMatcher.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/RegexMatcher.java
@@ -1,0 +1,44 @@
+package org.jboss.reddeer.swt.matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher to match text (String) to given regular expression.
+ * 
+ * @author rhopp
+ *
+ */
+
+public class RegexMatcher extends TypeSafeMatcher<String> {
+
+	private final String regex;
+
+	/**
+	 * Default constructor.
+	 * 
+	 * @param regex
+	 *            regular expression to match against.
+	 */
+
+	public RegexMatcher(String regex) {
+		this.regex = regex;
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("matches regular expression of \"" + regex
+				+ "\"");
+	}
+
+	@Override
+	protected boolean matchesSafely(String textToMatch) {
+		return textToMatch.matches(regex);
+	}
+
+	@Override
+	public String toString() {
+		return "Matcher matching text to given regular expression";
+	}
+
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/WithRegexMatcher.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/WithRegexMatcher.java
@@ -8,6 +8,10 @@ import org.hamcrest.Description;
  * @author Jiri Peterka
  * @author Radoslav Rabara
  * 
+ * @deprecated in 0.6. Use plain {@link RegexMatcher} in combination with some
+ *             other matcher (for example {@link WithTextMatcher} or
+ *             {@link WithTooltipTextMatcher}).
+ * 
  */
 public class WithRegexMatcher extends AbstractWidgetWithTextMatcher {
 

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/WithRegexMatchers.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/WithRegexMatchers.java
@@ -14,6 +14,10 @@ import org.hamcrest.Matcher;
  * 
  * @author Jiri Peterka
  * @author Radoslav Rabara
+ * 
+  * @deprecated in 0.6. Use plain {@link RegexMatjcher} in combination with some
+ *             other matchers (for example {@link WithTextMatchers} or
+ *             {@link WithTooltipTextMatchers}).
  */
 public class WithRegexMatchers {
 

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/WithTooltipTextMatcher.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/WithTooltipTextMatcher.java
@@ -1,0 +1,68 @@
+package org.jboss.reddeer.swt.matcher;
+
+import org.eclipse.swt.widgets.Widget;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsEqual;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.handler.WidgetHandler;
+
+/**
+ * Matcher which matches widgets with given tooltip
+ * 
+ * @author rhopp
+ *
+ */
+
+public class WithTooltipTextMatcher extends AbstractWidgetWithTextMatcher {
+
+	private Matcher<String> matcher;
+	
+	/**
+	 * Default constructor for matching widgets with ToolTip text
+	 * 
+	 * @param text
+	 */
+	
+	public WithTooltipTextMatcher(String text) {
+		this(new IsEqual<String>(text));
+	}
+	
+	
+	/**
+	 * Constructor for matching widgets ToolTip text using String matcher
+	 * 
+	 * @param matcher
+	 */
+	
+	public WithTooltipTextMatcher(Matcher<String> matcher) {
+		if (matcher == null)
+			throw new NullPointerException("matcher is null");
+		this.matcher = matcher;
+	}
+	
+	@Override
+	protected String extractWidgetText(Widget widget) {
+		try{
+			return WidgetHandler.getInstance().getToolTipText(widget);
+		} catch (SWTLayerException ex) {
+			return null;
+		}
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("with tooltip ").appendDescriptionOf(matcher);
+
+	}
+
+	@Override
+	protected boolean matches(String text) {
+		return matcher.matches(text);
+	}
+	
+	@Override
+	public String toString() {
+		return "Matcher matching widget which tooltip matches: "+matcher.toString();
+	}
+}

--- a/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/impl/view/AbstractView.java
+++ b/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/impl/view/AbstractView.java
@@ -17,8 +17,9 @@ import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.jboss.reddeer.swt.matcher.WithRegexMatchers;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
 import org.jboss.reddeer.swt.matcher.WithTextMatcher;
+import org.jboss.reddeer.swt.matcher.WithTextMatchers;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
@@ -176,8 +177,10 @@ public class AbstractView implements View {
 		// view is not opened, it has to be opened via menu
 		if (viewPart == null) {
 			log.info("Opening " + viewTitle() + " view via menu.");
-			WithRegexMatchers m = new WithRegexMatchers("Window.*",
-					"Show View.*", "Other...*");
+			WithTextMatchers m = new WithTextMatchers(new RegexMatcher[] {
+					new RegexMatcher("Window.*"),
+					new RegexMatcher("Show View.*"),
+					new RegexMatcher("Other...*") });
 			Menu menu = new ShellMenu(m.getMatchers());
 			menu.select();
 			new DefaultShell(SHOW_VIEW);

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/MenuTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/MenuTest.java
@@ -11,9 +11,10 @@ import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.impl.menu.ContextMenu;
 import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
 import org.jboss.reddeer.swt.matcher.WithMnemonicTextMatcher;
-import org.jboss.reddeer.swt.matcher.WithRegexMatcher;
-import org.jboss.reddeer.swt.matcher.WithRegexMatchers;
+import org.jboss.reddeer.swt.matcher.WithTextMatcher;
+import org.jboss.reddeer.swt.matcher.WithTextMatchers;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +53,7 @@ public class MenuTest {
 		new DefaultShell();
 		@SuppressWarnings("unchecked")
 		Menu m = new ShellMenu(new WithMnemonicTextMatcher("Help"),
-			new WithRegexMatcher("About.*"));
+			new WithTextMatcher(new RegexMatcher("About.*")));
 		m.select();
 		Shell s = new DefaultShell();
 		s.close();
@@ -72,7 +73,11 @@ public class MenuTest {
 
 		log.info("regex menu test");
 		try {
-			WithRegexMatchers m = new WithRegexMatchers("Win.*", "Pref.*");
+			RegexMatcher[] regexMatchers = { 
+					new RegexMatcher("Win.*"),
+					new RegexMatcher("Pref.*") 
+			};
+			WithTextMatchers m = new WithTextMatchers(regexMatchers);
 			new ShellMenu(m.getMatchers());
 		} catch (SWTLayerException e) {
 			fail("there should be no exception");
@@ -84,7 +89,11 @@ public class MenuTest {
 	public void unavailableMenuTest() {
 		log.info("unavailable regex menu test");
 		try {
-			WithRegexMatchers m = new WithRegexMatchers("Win.*", "Prefz.*");
+			RegexMatcher[] regexMatchers = { 
+					new RegexMatcher("Win.*"),
+					new RegexMatcher("Prefz.*") 
+			};
+			WithTextMatchers m = new WithTextMatchers(regexMatchers);
 			new ShellMenu(m.getMatchers());
 			fail("exception should be thrown");
 		} catch (SWTLayerException e) { // do nothing

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/ToolBarTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/ToolBarTest.java
@@ -24,8 +24,9 @@ import org.jboss.reddeer.swt.impl.toolbar.ShellToolItem;
 import org.jboss.reddeer.swt.impl.toolbar.ViewToolBar;
 import org.jboss.reddeer.swt.impl.toolbar.WorkbenchToolItem;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.jboss.reddeer.swt.matcher.WithRegexMatcher;
-import org.jboss.reddeer.swt.matcher.WithRegexMatchers;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
+import org.jboss.reddeer.swt.matcher.WithTextMatcher;
+import org.jboss.reddeer.swt.matcher.WithTextMatchers;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 import org.jboss.tools.reddeer.swt.test.model.TestModel;
 import org.junit.Before;
@@ -55,9 +56,9 @@ public class ToolBarTest {
 	
 	@Test 
 	public void workbenchToolBarRegexTest() {
-		
-		WithRegexMatcher rm = new WithRegexMatcher("RedDeer SWT Workbench.*");
-		ToolItem i = new WorkbenchToolItem(rm);
+		WithTextMatcher matcher = new WithTextMatcher(
+				new RegexMatcher("RedDeer SWT Workbench.*"));
+		ToolItem i = new WorkbenchToolItem(matcher);
 		i.click();
 		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());
 	}
@@ -84,7 +85,8 @@ public class ToolBarTest {
 
 	@Test
 	public void testToolItemInViewToolBarRegexClicked() {
-		WithRegexMatcher rm = new WithRegexMatcher("RedDeer SWT View.*");
+		WithTextMatcher rm = new WithTextMatcher(
+				new RegexMatcher("RedDeer SWT View.*"));
 		ToolItem i = new DefaultToolItem(rm);
 		i.click();
 		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());		
@@ -122,13 +124,16 @@ public class ToolBarTest {
 	public void testToolItemInShellToolBarRegexClicked() {
 		openPreferences();
 		new DefaultTreeItem(1).select();
-		ToolItem ti = new ShellToolItem(new WithRegexMatcher(".*ack.*"));
+		ToolItem ti = new ShellToolItem(new WithTextMatcher(new RegexMatcher(
+				".*ack.*")));
 		assertNotNull(ti);
 		closePreferences();			
 	}
 	
 	private void openPreferences() {
-		WithRegexMatchers m = new WithRegexMatchers("Window.*", "Preferences.*");
+		RegexMatcher[] array = { new RegexMatcher("Window.*"),
+				new RegexMatcher("Preferences.*") };
+		WithTextMatchers m = new WithTextMatchers(array);
 		Menu menu = new ShellMenu(m.getMatchers());
 		menu.select();
 		new DefaultShell("Preferences");

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/tree/DefaultTreeTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/tree/DefaultTreeTest.java
@@ -25,7 +25,8 @@ import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.jboss.reddeer.swt.matcher.WithRegexMatcher;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
+import org.jboss.reddeer.swt.matcher.WithTextMatcher;
 import org.jboss.reddeer.swt.test.SWTLayerTestCase;
 import org.jboss.reddeer.swt.test.ui.views.TreeEventsListener;
 import org.jboss.reddeer.swt.util.Display;
@@ -320,18 +321,29 @@ public class DefaultTreeTest extends SWTLayerTestCase {
 
 	@Test
 	public void testFindUsingRegexMatcher() {
+		RegexMatcher aMatcher = new RegexMatcher("A");
+		RegexMatcher aPlusMatcher = new RegexMatcher("A+");
+		RegexMatcher aPlusBMatcher = new RegexMatcher("A+B");
 		createTreeItems(tree.getSWTWidget());
 
 		String expected;
 		DefaultTreeItem dfi;
 
 		expected = "AA";
-		dfi = new DefaultTreeItem(new WithRegexMatcher("A"), new WithRegexMatcher("A+"));
-		assertEquals(String.format("Found item with text '%s', '%s' expected", dfi.getText(), expected),
-				expected, dfi.getText());
+		dfi = new DefaultTreeItem(new WithTextMatcher[]{
+				new WithTextMatcher(aMatcher),
+				new WithTextMatcher(aPlusMatcher)
+		});
+		assertEquals(
+				String.format("Found item with text '%s', '%s' expected",
+						dfi.getText(), expected), expected, dfi.getText());
 
 		expected = "AAB";
-		dfi = new DefaultTreeItem(new WithRegexMatcher("A"), new WithRegexMatcher("A+"), new WithRegexMatcher("A+B"));
+		dfi = new DefaultTreeItem(new WithTextMatcher[]{
+				new WithTextMatcher(aMatcher),
+				new WithTextMatcher(aPlusMatcher),
+				new WithTextMatcher(aPlusBMatcher)
+		});
 		assertEquals(String.format("Found item with text '%s', '%s' expected", dfi.getText(), expected),
 				expected, dfi.getText());
 	}

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/matcher/RegexMatcherTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/matcher/RegexMatcherTest.java
@@ -1,0 +1,30 @@
+package org.jboss.reddeer.swt.test.matcher;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.Matcher;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
+import org.junit.Test;
+
+public class RegexMatcherTest {
+
+	@Test
+	public void regexMatcherMatchesEverythingTest() {
+		Matcher<String> m = new RegexMatcher(".*");
+		assertThat("test", m);
+		assertThat("", m);
+	}
+
+	@Test
+	public void regexMatcherDigitsTest() {
+		Matcher<String> m = new RegexMatcher("\\d*");
+		assertThat("123", m);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void regexMatcherFailureTest() {
+		Matcher<String> m = new RegexMatcher("\\d*");
+		assertThat("123s", m);
+	}
+
+}


### PR DESCRIPTION
RegexMatcher for matching strings to regular expressions was added (do
not mistake it with RegexMatcher which was in version 0.5)
WithRegexMatcher was marked as deprecated as I'd like to encourage
people to use RegexMatcher in combination with another matchers (for
example WithLabelMatcher, WithTooltipMatcher, ...)
WithTooltipMatcher was added because I was missing this functionality in
RedDeer.
All recurences of WithRegexMatcher and WithRegexMatchers were hopefully
removed.
