### PR TITLE
Failing MavenPreferences tests

### DIFF
--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -101,6 +101,11 @@
                             <artifactId>org.eclipse.mylyn.bugzilla_feature.feature.group</artifactId>
                             <version>0.0.0</version>
                         </dependency>
+                         <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.m2e.feature.feature.group</artifactId>
+                            <version>0.0.0</version>
+                        </dependency>
 					</dependencies>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
They are failing due to the missing dependency in pom file to m2e feature. 
