### PR TITLE
Add deployment settings for archetype

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -27,4 +27,16 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<!-- For deployment of archetype to Nexus -->
+	<!--  Don't change "id" since it should match credentials entry in $M2_REPO/settings.xml -->
+	<distributionManagement>
+		<snapshotRepository>
+			<id>jboss-snapshots-repository</id>
+			<name>JBoss Snapshots Repository</name>
+			<url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
+			<uniqueVersion>false</uniqueVersion>
+		</snapshotRepository>
+	</distributionManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -133,15 +133,4 @@
 				</releases>
 		</repository>
 	</repositories>
-
-	<!-- For deployment of e.g. archetype to Nexus -->
-	<!--  Don't change "id" since it should match credentials entry in $M2_REPO/settings.xml -->
-	<distributionManagement>
-		<snapshotRepository>
-			<id>jboss-snapshots-repository</id>
-			<name>JBoss Snapshots Repository</name>
-			<url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
-			<uniqueVersion>false</uniqueVersion>
-		</snapshotRepository>
-	</distributionManagement>
 </project>


### PR DESCRIPTION
Since the reddeer archetype does not have a dependency on our root pom, it
attempts to add this dependency failed, we need to add the
distributionManagement settings to the archetype pom directly.
