### PR TITLE
Parsing text to styled and non styled text of TreeItem doesn't work properly

### DIFF
--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/viewer/handler/TreeViewerHandler.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/eclipse/jface/viewer/handler/TreeViewerHandler.java
@@ -152,7 +152,7 @@ public class TreeViewerHandler {
 						
 						tmpStyledTexts[i] = rawText.substring(range.start, range.start +
 								range.length).trim();
-						currentTextIndex = range.start + range.length + 1;
+						currentTextIndex = range.start + range.length;
 						i++;
 					}
 					


### PR DESCRIPTION
When the TreeItem's text is parsed, it assumes that between styled and non styled text is a space.
