### PR TITLE
NoClassDefFoundError: org/apache/commons/logging/LogFactory

### DIFF
--- a/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swt,
  org.junit;bundle-version="4.0.0",
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.common;bundle-version="0.6.0"
+ org.jboss.reddeer.common;bundle-version="0.6.0",
+ org.apache.commons.logging;bundle-version="1.1.1"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,


### PR DESCRIPTION
The following error occurs if I try to run a test which uses property based requirement

java.lang.NoClassDefFoundError: org/apache/commons/logging/LogFactory
    at org.apache.commons.beanutils.PropertyUtilsBean.<init>(PropertyUtilsBean.java:132)
    at org.jboss.reddeer.junit.internal.configuration.setter.ConfigurationSetter.inject(ConfigurationSetter.java:31)
    at org.jboss.reddeer.junit.internal.configuration.setter.ConfigurationSetter.inject(ConfigurationSetter.java:27)
    at org.jboss.reddeer.junit.internal.configuration.setter.ConfigurationSetter.set(ConfigurationSetter.java:22)
    at org.jboss.reddeer.junit.internal.configuration.configurator.PropertyBasedConfigurator.configure(PropertyBasedConfigurator.java:47)
    at org.jboss.reddeer.junit.internal.configuration.RequirementsConfigurationImpl.configure(RequirementsConfigurationImpl.java:40)
    at org.jboss.reddeer.junit.internal.requirement.RequirementsBuilder.build(RequirementsBuilder.java:39)
    at org.jboss.reddeer.junit.internal.requirement.RequirementsBuilder.build(RequirementsBuilder.java:31)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunnerBuilder.runnerForClass(RequirementsRunnerBuilder.java:53)
    at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
    at org.junit.runners.model.RunnerBuilder.runners(RunnerBuilder.java:101)
    at org.junit.runners.model.RunnerBuilder.runners(RunnerBuilder.java:87)
    at org.junit.runners.Suite.<init>(Suite.java:101)
    at org.jboss.reddeer.junit.internal.runner.NamedSuite.<init>(NamedSuite.java:39)
    at org.jboss.reddeer.junit.runner.RedDeerSuite.createSuite(RedDeerSuite.java:83)
    at org.jboss.reddeer.junit.runner.RedDeerSuite.<init>(RedDeerSuite.java:62)
    at org.jboss.reddeer.junit.runner.RedDeerSuite.<init>(RedDeerSuite.java:49)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
    at org.junit.internal.builders.AnnotatedBuilder.buildRunner(AnnotatedBuilder.java:33)
    at org.junit.internal.builders.AnnotatedBuilder.runnerForClass(AnnotatedBuilder.java:21)
    at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
    at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:26)
    at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
    at org.junit.internal.requests.ClassRequest.getRunner(ClassRequest.java:26)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.<init>(JUnit4TestReference.java:33)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestClassReference.<init>(JUnit4TestClassReference.java:25)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.createTest(JUnit4TestLoader.java:48)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.loadTests(JUnit4TestLoader.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:452)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
    at org.jboss.reddeer.eclipse.core.RemotePluginTestRunner.main(RemotePluginTestRunner.java:56)
    at org.jboss.reddeer.eclipse.core.UITestApplication.runTests(UITestApplication.java:115)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:72)
    at java.lang.Thread.run(Thread.java:744)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.logging.LogFactory cannot be found by org.jboss.reddeer.junit_0.6.0.qualifier
    at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:501)
    at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:421)
    at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:412)
    at org.eclipse.osgi.internal.baseadaptor.DefaultClassLoader.loadClass(DefaultClassLoader.java:107)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
    ... 38 more
