### PR TITLE
Refactor ShellMenu

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/MenuHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/MenuHandler.java
@@ -1,0 +1,127 @@
+package org.jboss.reddeer.swt.handler;
+
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.MenuItem;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+
+/**
+ * Contains methods for handling UI operations on {@link MenuItem} widgets.
+ * 
+ * @author Lucia Jelinkova
+ *
+ */
+public class MenuHandler {
+	
+	private static MenuHandler instance;
+
+	private MenuHandler() {
+
+	}
+
+	/**
+	 * Gets instance of MenuHandler.
+	 * 
+	 * @return instance of MenuHandler
+	 */
+	public static MenuHandler getInstance() {
+		if (instance == null) {
+			instance = new MenuHandler();
+		}
+		return instance;
+	}
+	
+	public boolean isSelected(final MenuItem item){
+		return Display.syncExec(new ResultRunnable<Boolean>() {
+
+			@Override
+			public Boolean run() {
+				if(((item.getStyle() & SWT.RADIO) != 0) || ((item.getStyle() & SWT.CHECK) != 0)){
+					return item.getSelection();
+				}
+				return false;
+			}
+		});
+	}
+	
+	/**
+	 * Selects (click) for MenuItem
+	 * @param item to click
+	 */
+	public void select(final MenuItem item) {
+		
+		if(!isMenuEnabled(item)){
+			throw new SWTLayerException("Menu item is not enabled");
+		} else {
+			Display.syncExec(new Runnable() {
+
+				@Override
+				public void run() {
+					if(((item.getStyle() & SWT.RADIO) != 0) || ((item.getStyle() & SWT.CHECK) != 0)){
+						item.setSelection(!item.getSelection());
+					}
+				}
+			});
+			
+			Display.asyncExec(new Runnable() {
+
+				@Override
+				public void run() {
+					final Event event = new Event();
+					event.time = (int) System.currentTimeMillis();
+					event.widget = item;
+					event.item = item;
+					event.display = item.getDisplay();
+					event.type = SWT.Selection;
+					
+					item.notifyListeners(SWT.Selection, event);
+				}
+			});
+			Display.syncExec(new Runnable() {
+				@Override
+				public void run() {
+
+				}
+			});
+		}
+	}
+	
+	/**
+	 * Selects (click) for ActionContributionItem
+	 * @param item to click
+	 */
+	public void select(final ActionContributionItem item){
+		String actionNormalized = item.getAction().getText().replace("&", "");
+		if(!item.isEnabled()){
+			throw new SWTLayerException("Menu item " +actionNormalized+" is not enabled");
+		} else if(!item.isVisible()){
+			throw new SWTLayerException("Menu item " +actionNormalized+" is not visible");
+		} else{
+			Display.asyncExec(new Runnable() {
+				@Override
+				public void run() {
+					item.getAction().run();
+				}
+			});
+		}
+	}
+	
+	/**
+	 * 
+	 * Check weather or not menuitem is enabled
+	 * 
+	 * @param menuItem
+	 */
+	private boolean isMenuEnabled(final MenuItem menuItem) {
+		boolean enabled = Display.syncExec(new ResultRunnable<Boolean>() {
+			public Boolean run() {
+				return menuItem.getEnabled();
+			}
+		});
+
+		return enabled;
+	}
+}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ContextMenu.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ContextMenu.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
 import org.jboss.reddeer.swt.api.Menu;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.handler.ActionContributionItemHandler;
+import org.jboss.reddeer.swt.handler.MenuHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.lookup.MenuLookup;
 import org.jboss.reddeer.swt.matcher.WithMnemonicTextMatchers;
@@ -56,19 +57,17 @@ public class ContextMenu extends AbstractMenu implements Menu {
 	
 	@Override
 	public void select() {
-		MenuLookup l = new MenuLookup();
 		if(menuItem != null){
-			l.select(menuItem);
+			MenuHandler.getInstance().select(menuItem);
 		} else {
-			l.select(item);
+			MenuHandler.getInstance().select(item);
 		}
 	}
 	
 	@Override
 	public boolean isSelected() {
-		MenuLookup l = new MenuLookup();
 		if(menuItem != null){
-			return l.isSelected(menuItem);
+			return MenuHandler.getInstance().isSelected(menuItem);
 		} else {
 			return false;
 		}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ShellMenu.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ShellMenu.java
@@ -9,6 +9,7 @@ import org.jboss.reddeer.common.platform.RunningPlatform;
 import org.jboss.reddeer.swt.api.Menu;
 import org.jboss.reddeer.swt.api.Shell;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.handler.MenuHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.lookup.MenuLookup;
 import org.jboss.reddeer.swt.lookup.ShellLookup;
@@ -58,16 +59,14 @@ public class ShellMenu extends AbstractMenu implements Menu {
 		this.matchers = matchers;
 		setMacOsMenuProperties();
 		if (!isSubmenuOfMacEclipseMenu) {
-			MenuLookup ml = new MenuLookup();
-			menuItem = ml.lookFor(ml.getActiveShellTopMenuItems(), matchers);
+			getSWTWidget();
 		}
 	}
 	
 	@Override
 	public void select() {
 		if (!isSubmenuOfMacEclipseMenu){
-			MenuLookup ml = new MenuLookup();
-			ml.select(menuItem);
+			MenuHandler.getInstance().select(getSWTWidget());
 		} else {
 			if (macEclipseMenuCommand.equals(MacEclipseMenuCommand.PREFERENCES)){
 				openPreferencesDialog();
@@ -81,9 +80,8 @@ public class ShellMenu extends AbstractMenu implements Menu {
 	
 	@Override
 	public boolean isSelected() {
-		MenuLookup l = new MenuLookup();
-		if(menuItem != null){
-			return l.isSelected(menuItem);
+		if(getSWTWidget() != null){
+			return MenuHandler.getInstance().isSelected(getSWTWidget());
 		} else {
 			return false;
 		}
@@ -124,8 +122,7 @@ public class ShellMenu extends AbstractMenu implements Menu {
 	public String getText() {
 		if (!isSubmenuOfMacEclipseMenu){
 			MenuLookup ml = new MenuLookup();
-			MenuItem i = ml.lookFor(ml.getActiveShellTopMenuItems(), matchers);
-			String text = ml.getMenuItemText(i);
+			String text = ml.getMenuItemText(getSWTWidget());
 			return text;
 		}
 		else{
@@ -149,11 +146,15 @@ public class ShellMenu extends AbstractMenu implements Menu {
 	}
 	
 	public MenuItem getSWTWidget(){
+		if (menuItem == null || menuItem.isDisposed()){
+			MenuLookup ml = new MenuLookup();
+			menuItem = ml.lookFor(ml.getActiveShellTopMenuItems(), matchers);
+		}
 		return menuItem;
 	}
 	
 	@Override
 	public boolean isEnabled() {
-		return WidgetHandler.getInstance().isEnabled(menuItem);
+		return WidgetHandler.getInstance().isEnabled(getSWTWidget());
 	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ToolbarMenu.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ToolbarMenu.java
@@ -5,6 +5,7 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.hamcrest.Matcher;
 import org.jboss.reddeer.swt.api.Menu;
 import org.jboss.reddeer.swt.handler.ActionContributionItemHandler;
+import org.jboss.reddeer.swt.handler.MenuHandler;
 import org.jboss.reddeer.swt.lookup.MenuLookup;
 import org.jboss.reddeer.swt.matcher.WithMnemonicTextMatchers;
 
@@ -29,8 +30,7 @@ public class ToolbarMenu extends AbstractMenu implements Menu{
 
 	@Override
 	public void select() {
-		MenuLookup l = new MenuLookup();
-		l.select(item);
+		MenuHandler.getInstance().select(item);
 	}
 	
 	@Override

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/MenuLookup.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/MenuLookup.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.jboss.reddeer.common.logging.Logger;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IMenuManager;
@@ -24,8 +23,10 @@ import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.hamcrest.Matcher;
+import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.handler.MenuHandler;
 import org.jboss.reddeer.swt.handler.WidgetHandler;
 import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
@@ -148,6 +149,11 @@ public class MenuLookup {
 		return lastMenuItem;
 	}
 	
+	/**
+	 * @deprecated Since 0.6.0. Use {@link MenuHandler}
+	 * @param item
+	 * @return
+	 */
 	public boolean isSelected(final MenuItem item){
 		return Display.syncExec(new ResultRunnable<Boolean>() {
 
@@ -162,6 +168,7 @@ public class MenuLookup {
 	}
 
 	/**
+	 * @deprecated Since 0.6.0. Use {@link MenuHandler}
 	 * Selects (click) for MenuItem
 	 * @param item to click
 	 */
@@ -212,6 +219,7 @@ public class MenuLookup {
 		}
 	}
 	/**
+	 *  @deprecated Since 0.6.0. Use {@link MenuHandler}
 	 * Selects (click) for ActionContributionItem
 	 * @param item to click
 	 */
@@ -414,6 +422,8 @@ public class MenuLookup {
 		
 
 	/**
+	 * 
+	 *  
 	 * Hide menu
 	 * 
 	 * @param menu
@@ -441,21 +451,6 @@ public class MenuLookup {
 
 	}
 
-	/**
-	 * Check weather or not menuitem is enabled
-	 * 
-	 * @param menuItem
-	 */
-	private boolean isMenuEnabled(final MenuItem menuItem) {
-		boolean enabled = Display.syncExec(new ResultRunnable<Boolean>() {
-			public Boolean run() {
-				return menuItem.getEnabled();
-			}
-		});
-
-		return enabled;
-	}
-	
 	private IWorkbenchPart getActivePart(final boolean restore) {
 		IWorkbenchPart result = Display.syncExec(new ResultRunnable<IWorkbenchPart>() {
 
@@ -472,4 +467,20 @@ public class MenuLookup {
 		return result;		
 	}
 
+	/**
+	 * @deprecated Since 0.6.0. Use {@link MenuHandler}
+	 * 
+	 * Check weather or not menuitem is enabled
+	 * 
+	 * @param menuItem
+	 */
+	private boolean isMenuEnabled(final MenuItem menuItem) {
+		boolean enabled = Display.syncExec(new ResultRunnable<Boolean>() {
+			public Boolean run() {
+				return menuItem.getEnabled();
+			}
+		});
+
+		return enabled;
+	}
 }

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/menu/ShellMenuTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/menu/ShellMenuTest.java
@@ -1,0 +1,58 @@
+package org.jboss.reddeer.swt.test.impl.menu;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.handler.ShellHandler;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.matcher.RegexMatcher;
+import org.jboss.reddeer.swt.matcher.WithTextMatchers;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(RedDeerSuite.class)
+public class ShellMenuTest {
+	
+	@After
+	public void cleanup(){
+		ShellHandler.getInstance().closeAllNonWorbenchShells();
+	}
+	
+	@Test
+	@SuppressWarnings("unchecked")
+	public void openPreferences(){
+		new ShellMenu(new RegexMatcher("Window"), new RegexMatcher("Preferences")).select();
+		
+		DefaultShell activeShell = new DefaultShell();
+		assertThat(activeShell.getText(), is("Preferences"));
+	}
+	
+	@Test
+	@SuppressWarnings("unchecked")
+	public void openAbout(){
+		new ShellMenu(new RegexMatcher("Help"), new RegexMatcher("About.*")).select();
+		
+		DefaultShell activeShell = new DefaultShell();
+		assertThat(activeShell.getText(), is("About Eclipse Platform"));
+	}
+
+	@Test
+	public void getText(){
+		WithTextMatchers m = new WithTextMatchers(new RegexMatcher[] {
+				new RegexMatcher("Window.*"),
+				new RegexMatcher("Show View.*"),
+				new RegexMatcher("Other...*") });
+		
+		ShellMenu menu = new ShellMenu(m.getMatchers());
+		String menuText1 = menu.getText();
+		menu.select();
+		cleanup();
+		String menuText2 = menu.getText();
+		
+		assertEquals("Menu text has to be equal before and after select is called", menuText1, menuText2);
+	}
+}


### PR DESCRIPTION
Calling method getText() from method select() causes menu item to dispose (menu will be reopen and the old instance disposed). 

This seems to happen only if the menu has more than 2 path items, e.g
WithTextMatchers m = new WithTextMatchers(new RegexMatcher[] {
                new RegexMatcher("Window._"),
                new RegexMatcher("Show View._"),
                new RegexMatcher("Other...*") });
