### PR TITLE
dev_AbstractTree notifications do not work properly

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TreeHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/handler/TreeHandler.java
@@ -445,6 +445,8 @@ public class TreeHandler {
 				swtTreeItem.getParent().notifyListeners(event.type, event);
 			}
 		});
+		
+		Display.synchronize();
 	}
 
 	/**

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/util/Display.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/util/Display.java
@@ -44,6 +44,18 @@ public class Display {
 		return display;
 	}
 
+	/**
+	 * Help method used to flush all UI events from UI thread. 
+	 */
+	public static void synchronize(){
+		syncExec(new Runnable() {
+			
+			@Override
+			public void run() {
+			}
+		});
+	}
+	
 	public static void syncExec(Runnable runnable) {
 		syncExec(new VoidResultRunnable(runnable));
 	}


### PR DESCRIPTION
I discovered a bug when I deleted the last line in the following method in AbstractTree

``` java
@Override
public void doubleClick() {
   logger.debug("Double Click Tree Item " + getText());
   select();
   treeHandler.notifyTree(getSWTWidget(), treeHandler.createEventForTree(
   getSWTWidget(), SWT.MouseDoubleClick));
   treeHandler.notifyTree(getSWTWidget(), treeHandler.createEventForTree(
   getSWTWidget(), SWT.DefaultSelection));
   logger.info("Double Clicked on: " + this);
}
```

When the logging was removed, the last notification was not called. It is because there is `this.toString()` in logging message and it calls Display.syncExec which somehow flushes created event. 
