### PR TITLE
ShellMenu getText() reopens menu

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/AbstractMenu.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/AbstractMenu.java
@@ -1,6 +1,7 @@
 package org.jboss.reddeer.swt.impl.menu;
 
 import org.jboss.reddeer.common.logging.Logger;
+import org.eclipse.swt.widgets.MenuItem;
 import org.hamcrest.Matcher;
 import org.jboss.reddeer.swt.api.Menu;
 import org.jboss.reddeer.swt.handler.MenuHandler;
@@ -20,6 +21,7 @@ public abstract class AbstractMenu implements Menu {
 	protected Matcher<String>[] matchers;
 	protected MenuLookup ml = MenuLookup.getInstance();
 	protected MenuHandler mh = MenuHandler.getInstance();
+	protected MenuItem menuItem = null;
 
 
 	@Override

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ContextMenu.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ContextMenu.java
@@ -21,7 +21,7 @@ import org.jboss.reddeer.swt.util.ResultRunnable;
  */
 public class ContextMenu extends AbstractMenu implements Menu {
 	
-	private ActionContributionItem item;
+	private ActionContributionItem actionItem;
 	private MenuItem menuItem;
 
 	/**
@@ -43,8 +43,8 @@ public class ContextMenu extends AbstractMenu implements Menu {
 		menuItem = ml.lookFor(ml.getTopMenuMenuItemsFromFocus(),matchers);
 		if(menuItem == null){
 			log.info("No menu item found, looking for contribution item");
-			item = ml.lookFor(ml.getMenuContributionItems(), matchers);
-			if (item == null){
+			actionItem = ml.lookFor(ml.getMenuContributionItems(), matchers);
+			if (actionItem == null){
 				throw new SWTLayerException("Contribution item not found");
 			}
 		}
@@ -54,11 +54,10 @@ public class ContextMenu extends AbstractMenu implements Menu {
 	
 	@Override
 	public void select() {
-		
 		if(menuItem != null){
 			mh.select(menuItem);
 		} else {
-			mh.select(item);
+			mh.select(actionItem);
 		}
 	}
 	
@@ -74,17 +73,11 @@ public class ContextMenu extends AbstractMenu implements Menu {
 	
 	@Override
 	public String getText() {
-		if(item != null){
-			return item.getAction().getText().replace("&", "");
+		if(actionItem != null){
+			return actionItem.getAction().getText().replace("&", "");
 		} else {
-			return Display.syncExec(new ResultRunnable<String>() {
-				
-				@Override
-				public String run() {
-					return menuItem.getText().replace("&", "");
-					
-				}
-			});
+			String ret = mh.getMenuItemText(menuItem).replace("&", "");
+			return ret;
 		}
 	}
 
@@ -98,6 +91,6 @@ public class ContextMenu extends AbstractMenu implements Menu {
 		if(menuItem != null){
 			return WidgetHandler.getInstance().isEnabled(menuItem);
 		}
-		return ActionContributionItemHandler.getInstance().isEnabled(item);
+		return ActionContributionItemHandler.getInstance().isEnabled(actionItem);
 	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ShellMenu.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/menu/ShellMenu.java
@@ -22,7 +22,7 @@ import org.jboss.reddeer.swt.util.Display;
 @SuppressWarnings("restriction")
 public class ShellMenu extends AbstractMenu implements Menu {
 	
-	private MenuItem menuItem;
+	
 	private boolean isSubmenuOfMacEclipseMenu = false;
 	private MacEclipseMenuCommand macEclipseMenuCommand = null;
 
@@ -65,6 +65,7 @@ public class ShellMenu extends AbstractMenu implements Menu {
 	@Override
 	public void select() {
 		if (!isSubmenuOfMacEclipseMenu){
+			System.out.println(getText());
 			mh.select(menuItem);
 		} else {
 			if (macEclipseMenuCommand.equals(MacEclipseMenuCommand.PREFERENCES)){
@@ -120,8 +121,10 @@ public class ShellMenu extends AbstractMenu implements Menu {
 	@Override
 	public String getText() {
 		if (!isSubmenuOfMacEclipseMenu){
-			MenuItem i = ml.lookFor(ml.getActiveShellTopMenuItems(), matchers);
-			String text = mh.getMenuItemText(i);
+			if (menuItem == null) {
+				menuItem = ml.lookFor(ml.getActiveShellTopMenuItems(), matchers);
+			}
+			String text = mh.getMenuItemText(menuItem);
 			return text;
 		}
 		else{


### PR DESCRIPTION
Calling method getText() from method select() causes menu item to dispose (menu will be reopen and the old instance disposed).

This seems to happen only if the menu has more than 2 path items, e.g
WithTextMatchers m = new WithTextMatchers(new RegexMatcher[] {
new RegexMatcher("Window."),
new RegexMatcher("Show View."),
new RegexMatcher("Other...*") });
