### PR TITLE
Implement PreferenceDialog and improve API of Shells

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/WorkbenchPreferenceDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/WorkbenchPreferenceDialog.java
@@ -1,0 +1,106 @@
+package org.jboss.reddeer.eclipse.jdt.ui;
+
+import org.eclipse.swt.widgets.Shell;
+import org.jboss.reddeer.common.logging.Logger;
+import org.jboss.reddeer.swt.api.Menu;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
+import org.jboss.reddeer.swt.impl.button.CancelButton;
+import org.jboss.reddeer.swt.impl.button.OkButton;
+import org.jboss.reddeer.swt.impl.clabel.DefaultCLabel;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.jboss.reddeer.swt.lookup.ShellLookup;
+import org.jboss.reddeer.swt.util.Display;
+import org.jboss.reddeer.swt.util.ResultRunnable;
+import org.jboss.reddeer.swt.wait.WaitWhile;
+
+/**
+ * Workbench Preference Dialog implementation. 
+ * @author Jiri Peterka
+ *
+ */
+public class WorkbenchPreferenceDialog {
+	
+	public static final String DIALOG_TITLE = "Preferences";
+
+	protected final Logger log = Logger.getLogger(this.getClass());
+
+
+	/**
+	 * Opens Preference Dialog.
+	 */
+	public void open(){
+		// if preferences dialog is not open, open it
+		log.info("Open Preferences dialog");
+
+		boolean openedShell = false;
+		for (Shell s: ShellLookup.getInstance().getShells()) {
+			final Shell shell = s;
+			String text = Display.syncExec(new ResultRunnable<String>() {
+				@Override
+				public String run() {
+					return shell.getText();
+				}
+			});
+			if (text.equals(DIALOG_TITLE)) {
+				log.debug("Preferences dialog was already opened.");
+				openedShell = true;
+			}
+		}
+		if (!openedShell) {
+			log.debug("Preferences dialog was not already opened. Opening via menu.");
+			Menu menu = new ShellMenu("Window", "Preferences");
+			menu.select();
+		}
+	}
+	
+	/**
+	 * Opens selected page under Preference Dialog
+	 * @param path given path to preference
+	 */
+	public void open(String... path) {
+		open();
+		new DefaultShell(DIALOG_TITLE);
+		TreeItem t = new DefaultTreeItem(path);
+		t.select();
+	}
+
+	/**
+	 * Get name of the given preference page.
+	 * 
+	 * @return name of preference page
+	 */
+	public String getPageName() {
+		DefaultCLabel cl = new DefaultCLabel();
+		return cl.getText();
+	}
+	
+	/**
+	 * Presses Ok button on Preference Dialog. 
+	 */
+	public void ok() {
+		OkButton ok = new OkButton();
+		ok.click();
+		new WaitWhile(new ShellWithTextIsActive(DIALOG_TITLE)); 
+	}
+
+	/**
+	 * Presses Cancel button on Preference Dialog. 
+	 */
+	public void cancel() {
+		CancelButton cancel = new CancelButton();
+		cancel.click();
+		new WaitWhile(new ShellWithTextIsActive(DIALOG_TITLE));
+	}
+	
+	/**
+	 * Checks if Workbench Preference dialog is opened.
+	 */
+	public boolean isOpen() {
+		Shell shell = ShellLookup.getInstance().getShell(DIALOG_TITLE);
+		return (shell != null);		
+	}
+	
+}

--- a/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/preference/WorkbenchPreferencePage.java
+++ b/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/preference/WorkbenchPreferencePage.java
@@ -38,6 +38,7 @@ public class WorkbenchPreferencePage extends PreferencePage {
 
 	/**
 	 * Open preference shell and specific preference page in preference shell defined by path given in constructor.
+	 * @deprecated since 0.6, WorkbenchPreferenceDialog#open should be used
 	 */
 	public void open() {
 

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/preference/WorkbenchPreferenceDialogTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/preference/WorkbenchPreferenceDialogTest.java
@@ -1,0 +1,81 @@
+package org.jboss.reddeer.workbench.preference;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.jboss.reddeer.eclipse.jdt.ui.WorkbenchPreferenceDialog;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.api.Shell;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(RedDeerSuite.class)
+public class WorkbenchPreferenceDialogTest {
+	
+	private WorkbenchPreferenceDialog preferenceDialog;
+
+	@Before
+	public void setup(){
+	}
+
+	@Test
+	public void open(){
+		preferenceDialog = new WorkbenchPreferenceDialog();
+		preferenceDialog.open();
+		
+		
+		Shell shell = new DefaultShell();		
+		assertThat(shell.getText(), is(WorkbenchPreferencePage.DIALOG_TITLE));
+	}
+	
+	@Test
+	public void openPage(){
+		preferenceDialog = new WorkbenchPreferenceDialog();
+		preferenceDialog.open("General","Workspace");
+		
+		assertThat(preferenceDialog.getPageName(), is("Workspace"));		
+	}
+	
+	@Test
+	public void testPreferenceDialogCancel() {
+		testPreferenceDialogCancel(true);
+	}
+	
+	@Test
+	public void testPreferenceDialogOk() {
+		testPreferenceDialogCancel(false);
+	}
+
+	private void testPreferenceDialogCancel(boolean cancel){
+		preferenceDialog = new WorkbenchPreferenceDialog();
+		preferenceDialog.open();
+		Shell shell = new DefaultShell();
+		
+		assertThat(shell.getText(), is(WorkbenchPreferencePage.DIALOG_TITLE));
+		assertThat(preferenceDialog.isOpen(), is(true));
+		if (cancel) {
+			preferenceDialog.cancel();
+		} else {
+			preferenceDialog.ok();
+		}
+		assertThat(preferenceDialog.isOpen(), is(false));
+	}
+	
+	@After
+	public void cleanup(){
+		Shell shell = null;
+		try {
+			shell = new DefaultShell(WorkbenchPreferencePage.DIALOG_TITLE);
+		} catch (SWTLayerException e){
+			// not found, no action needed
+			return;
+		}
+		shell.close();
+	}
+	
+}


### PR DESCRIPTION
Currently there is PreferencePage that supplies API for wrapping shell
- PreferenceDialog and it's predecessor should implement actions like:
  - open();
  - isOpen();
  - cancel();
  - olk();
