### PR TITLE
ProjectItem improvement to work with styled text

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/Project.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/Project.java
@@ -116,7 +116,7 @@ public class Project {
 	 * hierarchy and on each layer at first try to find item specified by part of the
 	 * path as it is (whole text). If there is no item with whole text represented by 
 	 * the part of the path, then item is looked up by non-decorated text representing
-	 * this item. If there are more than two items in this step containing same non-deprecated
+	 * this item. If there are more than two items in this step containing same non-styled
 	 * text, then EclipseLayerException is thrown. 
 	 * 
 	 * 
@@ -137,7 +137,7 @@ public class Project {
 					// non existing item
 					throw new EclipseLayerException("Cannot get project item specified by path."
 							+ "Project item either does not exist or solution is ambiguous because "
-							+ "of existence of more items on the path with same name without decorators");					
+							+ "of existence of more items on the path with same name without decorators");
 				}
 			} 
 		}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/ProjectItem.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/packageexplorer/ProjectItem.java
@@ -90,17 +90,17 @@ public class ProjectItem {
 	}
 	
 	/**
-	 * Gets child of the project item with given text without decorators.
+	 * Gets child of the project item. At first the whole text of the child is
+	 * checked, then only non-decorated part.
 	 * 
-	 * @param text text of the project item without decorators to find
-	 * @return project item with specified text without decorators
+	 * @param text text of the project item
+	 * @return project item with the specified <var>text</var>
 	 */
 	public ProjectItem getChild(String text) {
 		String[] childPath = new String[path.length + 1];
 		System.arraycopy(path, 0, childPath, 0, path.length);
 		childPath[childPath.length - 1] = text;
-		return new ProjectItem(treeViewerHandler.getTreeItem(
-				treeItem, text), project, childPath);
+		return project.getProjectItem(childPath);
 	}
 	
 	/**
@@ -141,9 +141,6 @@ public class ProjectItem {
 	
 	/**
 	 * Gets list of children of the project item. 
-	 * <b>List is consisting of project items without decorators</b>.
-	 * If there are children distinguished only be decorators, use method 
-	 * {@link ProjectItem#getRawChildren()} instead.
 	 * 
 	 * @return list of children of the project item
 	 */
@@ -151,7 +148,7 @@ public class ProjectItem {
 		List<ProjectItem> children = new ArrayList<ProjectItem>();
 		
 		for (TreeItem item: treeItem.getItems()) {
-			String name = treeViewerHandler.getNonStyledText(item);
+			String name = item.getText();
 			String[] childPath = new String[path.length + 1];
 			System.arraycopy(path, 0, childPath, 0, path.length);
 			childPath[childPath.length - 1] = name;


### PR DESCRIPTION
Methods should be able to work with styled text (see related problem #731)

Method ProjectItem#getChildren should work even if there are children distinguished only be decorators.
Method ProjectItem#getChild should be more universal and at first check the whole text and then just the non-decorated part.
