### PR TITLE
Increase Timeout for Eclipse tests

### DIFF
--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<properties>
-		<surefire.timeout>4500</surefire.timeout>
+		<surefire.timeout>5400</surefire.timeout>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
4500s seems to be not enough for Mac anymore
