### PR TITLE
jpeterka_Cannot run only one test method from Eclipse IDE

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/runner/RedDeerSuite.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/runner/RedDeerSuite.java
@@ -1,9 +1,11 @@
 package org.jboss.reddeer.junit.runner;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.junit.extensionpoint.IAfterTest;
 import org.jboss.reddeer.junit.extensionpoint.IBeforeTest;
 import org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration;
@@ -13,10 +15,12 @@ import org.jboss.reddeer.junit.internal.extensionpoint.BeforeTestInitialization;
 import org.jboss.reddeer.junit.internal.runner.EmptySuite;
 import org.jboss.reddeer.junit.internal.runner.NamedSuite;
 import org.jboss.reddeer.junit.internal.runner.RequirementsRunnerBuilder;
-import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.junit.internal.runner.TestsExecutionManager;
 import org.jboss.reddeer.junit.internal.runner.TestsWithoutExecutionSuite;
+import org.junit.runner.Description;
 import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runner.notification.RunListener;
 import org.junit.runners.Suite;
 import org.junit.runners.model.InitializationError;
@@ -24,24 +28,25 @@ import org.junit.runners.model.RunnerBuilder;
 
 /**
  * 
- * Allows to run the tests (single or a suite) for each configuration file provided. 
+ * Allows to run the tests (single or a suite) for each configuration file provided.
  * 
  * @author Lucia Jelinkova
- *
+ * 
  */
 public class RedDeerSuite extends Suite {
-	
+
 	private static final Logger log = Logger.getLogger(RedDeerSuite.class);
-	// this variable has to set within static initialization block in child class
+	// this variable has to set within static initialization block in child
+	// class
 	// in order to add custom listeners
 	protected static RunListener[] runListeners;
-	
+
 	private static List<IBeforeTest> beforeTestExtensions = RedDeerSuite.initializeBeforeTestExtensions();
-	
+
 	private static List<IAfterTest> afterTestExtensions = RedDeerSuite.initializeAfterTestExtensions();
-	
+
 	/**
-	 * Called by the JUnit framework. 
+	 * Called by the JUnit framework.
 	 * 
 	 * @param clazz
 	 * @param builder
@@ -52,8 +57,8 @@ public class RedDeerSuite extends Suite {
 	}
 
 	/**
-	 * The {@link EmptySuite} makes sure that the @BeforeClass and @AfterClass are not called
-	 * on the suite class too often. 
+	 * The {@link EmptySuite} makes sure that the @BeforeClass and @AfterClass are not called on the suite class too
+	 * often.
 	 * 
 	 * @param clazz
 	 * @param builder
@@ -63,55 +68,57 @@ public class RedDeerSuite extends Suite {
 	protected RedDeerSuite(Class<?> clazz, RunnerBuilder builder, SuiteConfiguration config) throws InitializationError {
 		super(EmptySuite.class, createSuite(clazz, config));
 	}
-	
+
 	/**
-	 * Creates a new suite for each configuration file found. 
+	 * Creates a new suite for each configuration file found.
 	 * 
 	 * @param clazz
 	 * @param config
 	 * @return
 	 * @throws InitializationError
 	 */
-	protected static List<Runner> createSuite(Class<?> clazz, SuiteConfiguration config) throws InitializationError{
+	protected static List<Runner> createSuite(Class<?> clazz, SuiteConfiguration config) throws InitializationError {
 		log.info("Creating RedDeer suite...");
 		TestsExecutionManager testsManager = new TestsExecutionManager();
 		List<Runner> configuredSuites = new ArrayList<Runner>();
 		boolean isSuite = isSuite(clazz);
-		
-		for (TestRunConfiguration testRunConfig : config.getTestRunConfigurations()){
+
+		for (TestRunConfiguration testRunConfig : config.getTestRunConfigurations()) {
 			log.info("Adding suite with name " + testRunConfig.getId() + " to RedDeer suite");
-			if (isSuite){
-				configuredSuites.add(new NamedSuite(clazz, new RequirementsRunnerBuilder(testRunConfig,runListeners, beforeTestExtensions, afterTestExtensions, testsManager), testRunConfig.getId()));
+			if (isSuite) {
+				configuredSuites.add(new NamedSuite(clazz, new RequirementsRunnerBuilder(testRunConfig, runListeners,
+						beforeTestExtensions, afterTestExtensions, testsManager), testRunConfig.getId()));
 			} else {
-				configuredSuites.add(new NamedSuite(new Class[]{clazz}, new RequirementsRunnerBuilder(testRunConfig,runListeners, beforeTestExtensions, afterTestExtensions, testsManager), testRunConfig.getId()));
+				configuredSuites.add(new NamedSuite(new Class[] { clazz }, new RequirementsRunnerBuilder(testRunConfig,
+						runListeners, beforeTestExtensions, afterTestExtensions, testsManager), testRunConfig.getId()));
 			}
 		}
-		
-		if(!testsManager.allTestsAreExecuted()) {
+
+		if (!testsManager.allTestsAreExecuted()) {
 			if (isSuite) {
 				configuredSuites.add(new TestsWithoutExecutionSuite(clazz, testsManager));
 			} else {
-				configuredSuites.add(new TestsWithoutExecutionSuite(new Class[]{clazz}, testsManager));
+				configuredSuites.add(new TestsWithoutExecutionSuite(new Class[] { clazz }, testsManager));
 			}
 		}
 		log.info("RedDeer suite created");
 		return configuredSuites;
 	}
-	
+
 	private static boolean isSuite(Class<?> clazz) {
 		SuiteClasses annotation = clazz.getAnnotation(SuiteClasses.class);
 		return annotation != null;
 	}
-	
+
 	@Override
 	protected String getName() {
 		return "Red Deer Suite";
 	}
-	
+
 	/**
 	 * Initializes all Before Test extensions
 	 */
-	private static List<IBeforeTest> initializeBeforeTestExtensions(){
+	private static List<IBeforeTest> initializeBeforeTestExtensions() {
 		List<IBeforeTest> beforeTestExts;
 		// check if eclipse is running
 		try {
@@ -143,5 +150,69 @@ public class RedDeerSuite extends Suite {
 		}
 		return afterTestExts;
 	}
-	
+
+	@Override
+	public void filter(Filter filter) throws NoTestsRemainException {
+		super.filter(new FilterDecorator(filter));
+	}
+
+	/**
+	 * Running single test in case of parameterized test causes issue as explained in
+	 * http://youtrack.jetbrains.com/issue/IDEA-65966
+	 * 
+	 * As a workaround we wrap the original filter and then pass it a wrapped description which removes the parameter
+	 * part (See deparametrizedName).
+	 */
+	private static final class FilterDecorator extends Filter {
+		private final Filter delegate;
+
+		/**
+		 * Constructs the decorator with a given filter.
+		 * 
+		 * @param delegate
+		 *            Filter which will be decorated
+		 */
+		private FilterDecorator(Filter delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public boolean shouldRun(Description description) {
+			return delegate.shouldRun(wrap(description));
+		}
+
+		@Override
+		public String describe() {
+			return delegate.describe();
+		}
+	}
+
+	/**
+	 * Wraps a given description with a new display name (see deparametrizedName).
+	 * 
+	 * @param description
+	 *            Description
+	 * @return Description with correct display name
+	 */
+	private static Description wrap(Description description) {
+		String name = description.getDisplayName();
+		String fixedName = deparametrizedName(name);
+		Description clonedDescription = Description.createSuiteDescription(fixedName, description.getAnnotations()
+				.toArray(new Annotation[0]));
+		for (Description child : description.getChildren()) {
+			clonedDescription.addChild(wrap(child));
+		}
+		return clonedDescription;
+	}
+
+	/**
+	 * Removes ' default' from a given description name.
+	 * 
+	 * @param name
+	 *            Description name
+	 * @return Description name without ' default'
+	 */
+	private static String deparametrizedName(String name) {
+		return name.replaceAll(" default", "");
+	}
 }


### PR DESCRIPTION
In run configuration we can specify a test class and also a test method. But when we specify the test method the following error occurs

Unrooted Tests

java.lang.Exception: No tests found matching Method contextMenuTest(org.jboss.reddeer.swt.test.MenuTest) from org.junit.internal.requests.ClassRequest@2facf711
    at org.junit.internal.requests.FilterRequest.getRunner(FilterRequest.java:35)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.<init>(JUnit4TestReference.java:33)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestMethodReference.<init>(JUnit4TestMethodReference.java:25)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.createTest(JUnit4TestLoader.java:54)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.loadTests(JUnit4TestLoader.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:452)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
    at org.jboss.reddeer.eclipse.core.RemotePluginTestRunner.main(RemotePluginTestRunner.java:56)
    at org.jboss.reddeer.eclipse.core.UITestApplication.runTests(UITestApplication.java:115)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:72)
    at java.lang.Thread.run(Thread.java:744)
