### PR TITLE
WaitTimeoutExpiredException thrown from AbstractWait has quite unreadable message

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/AbstractWait.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/AbstractWait.java
@@ -63,6 +63,12 @@ public abstract class AbstractWait {
 	 */
 	public AbstractWait(WaitCondition condition, TimePeriod timePeriod,
 			boolean throwRuntimeException) {
+		if(condition == null) {
+			throw new IllegalArgumentException("condition can't be null");
+		}
+		if(timePeriod == null) {
+			throw new IllegalArgumentException("timePeriod can't be null");
+		}
 		this.timeout = timePeriod;
 		this.throwTimeoutException = throwRuntimeException;
 
@@ -139,13 +145,13 @@ public abstract class AbstractWait {
 			throw new RuntimeException("Sleep interrupted", e);
 		}
 	}
-	
+
 	private boolean timeoutExceeded(WaitCondition condition, long limit) {
 		if (System.currentTimeMillis() > limit) {
 			if (throwTimeoutException()) {
 				log.debug(this.description()  + condition.description() + " failed, an exception will be thrown");
 				throw new WaitTimeoutExpiredException("Timeout after: "
-						+ timeout + " ms.: " + condition.description());
+						+ timeout.getSeconds() + " s.: " + condition.description());
 			} else {
 				log.debug(this.description()  + condition.description() + " failed, NO exception will be thrown");
 				return true;

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/TimePeriod.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/wait/TimePeriod.java
@@ -55,4 +55,9 @@ public class TimePeriod {
 		}
 		return new TimePeriod(seconds);
 	}
+
+	@Override
+	public String toString() {
+		return "Time period " + seconds + " s.";
+	}
 }


### PR DESCRIPTION
```
org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: org.jboss.reddeer.swt.wait.TimePeriod@7a302733 ms.: widget is enabled
    at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:147)
    at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:100)
    at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:69)
    at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
    at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
```

This is the problem:

> Timeout after: **org.jboss.reddeer.swt.wait.TimePeriod@7a302733** ms
