### PR TITLE
NPE when the method activate() is called before the view is opened

### DIFF
--- a/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/impl/view/AbstractView.java
+++ b/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/impl/view/AbstractView.java
@@ -25,6 +25,7 @@ import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 import org.jboss.reddeer.workbench.api.View;
 import org.jboss.reddeer.workbench.api.WorkbenchPart;
+import org.jboss.reddeer.workbench.exception.WorkbenchLayerException;
 import org.jboss.reddeer.workbench.exception.WorkbenchPartNotFound;
 import org.jboss.reddeer.workbench.handler.ViewHandler;
 import org.jboss.reddeer.workbench.handler.WorkbenchPartHandler;
@@ -108,6 +109,7 @@ public class AbstractView implements View {
 	 */
 	@Override
 	public void activate() {
+		viewPartIsNotNull();
 		ViewHandler.getInstance().setFocus(viewPart, viewTitle());
 	}
 
@@ -161,10 +163,7 @@ public class AbstractView implements View {
 
 	@Override
 	public void close() {
-		if (viewPart == null) {
-			throw new UnsupportedOperationException("Cannot close view "
-					+ "before initialization provided by open method");
-		}
+		viewPartIsNotNull();
 		ViewHandler.getInstance().close(viewPart);
 		viewPart = null;
 	}
@@ -261,5 +260,13 @@ public class AbstractView implements View {
 			return part;
 		}
 
+	}
+
+	private void viewPartIsNotNull() {
+		if (viewPart == null) {
+			throw new WorkbenchLayerException("Cannot perform the specified "
+					+ "operation before initialization "
+					+ "provided by open method");
+		}
 	}
 }

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/view/ViewTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/view/ViewTest.java
@@ -2,6 +2,7 @@ package org.jboss.reddeer.workbench.test.view;
 
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.workbench.api.View;
+import org.jboss.reddeer.workbench.exception.WorkbenchLayerException;
 import org.jboss.reddeer.workbench.exception.WorkbenchPartNotFound;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 import org.junit.Test;
@@ -9,68 +10,84 @@ import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
 public class ViewTest {
-	
+
 	@Test
 	public void testInitializeRegisteredView() {
-		
 		new WorkbenchView("Workbench Test");
-		
 	}
-	
+
 	@Test(expected=WorkbenchPartNotFound.class)
 	public void testInitializeNonregisteredView() {
-		
 		new WorkbenchView("Nonexist View");
-		
 	}
-	
+
 	@Test
 	public void testOpenAndCloseView() {
-		
 		View customView = new WorkbenchView("Workbench Test");
 		customView.open();
 		customView.close();
-		
 	}
-	
+
 	@Test
 	public void testOpenAndCloseViewFullPath() {
-		
 		View customView = new WorkbenchView("Red Deer Test Workbench", "Workbench Test");
 		customView.open();
 		customView.close();
-		
 	}
-	
+
 	@Test
 	public void testOpenClosedView() {
-		
 		View customView = new WorkbenchView("Workbench Test");
 		customView.open();
 		customView.close();
-		
+
 		customView.open();
 		customView.close();
 	}
-	
+
 	@Test
 	public void testCloseNonFocusedView() {
-		
 		View customView = new WorkbenchView("Workbench Test");
 		customView.open();
 		View markersView = new WorkbenchView("Markers");
 		markersView.open();
-		
+
 		customView.close();
 		markersView.close();
 	}
-	
-	@Test(expected=UnsupportedOperationException.class)
+
+	@Test(expected=WorkbenchLayerException.class)
 	public void testCloseNoninitializedView() {
-		
 		View customView = new WorkbenchView("Workbench Test");
 		customView.close();
-		
 	}
-	
+
+	@Test(expected=WorkbenchLayerException.class)
+	public void testActivateNoninitializedView() {
+		View customView = new WorkbenchView("Workbench Test");
+		customView.activate();
+	}
+
+	@Test
+	public void testActivateNonFocusedView() {
+		View customView = new WorkbenchView("Workbench Test");
+		customView.open();
+		
+		View markersView = new WorkbenchView("Markers");
+		markersView.open();
+
+		customView.activate();
+
+		customView.close();
+		markersView.close();
+	}
+
+	@Test
+	public void testMaximizeMinimalizedView() {
+		View customView = new WorkbenchView("Workbench Test");
+		customView.open();
+		customView.minimize();
+		customView.maximize();
+		customView.close();
+	}
 }

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/view/impl/WorkbenchViewTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/view/impl/WorkbenchViewTest.java
@@ -8,6 +8,7 @@ import org.hamcrest.core.IsNot;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.lookup.WorkbenchLookup;
 import org.jboss.reddeer.workbench.api.View;
+import org.jboss.reddeer.workbench.exception.WorkbenchLayerException;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,14 +28,14 @@ public class WorkbenchViewTest  {
 		markersView = new WorkbenchView(MARKERS_VIEW_TITLE);
 		try {
 			markersView.close();
-		} catch (UnsupportedOperationException uoe) {
+		} catch (WorkbenchLayerException uoe) {
 			// Markes view is not opened, do nothing here
 		}
 
 		projectExplorerView = new WorkbenchView(PROJECT_EXPLORER_VIEW_TITLE);
 		try {
 			projectExplorerView.close();
-		} catch (UnsupportedOperationException uoe) {
+		} catch (WorkbenchLayerException uoe) {
 			// Project Explorer view is not opened, do nothing here
 		}
 	}
@@ -55,14 +56,14 @@ public class WorkbenchViewTest  {
 		
 	}
 	
-	@Test(expected=UnsupportedOperationException.class)
+	@Test(expected=WorkbenchLayerException.class)
 	public void testCloseNonInstantiatedView() {
 		
 		markersView.close();
 		
 	}
 	
-	@Test(expected=UnsupportedOperationException.class)
+	@Test(expected=WorkbenchLayerException.class)
 	public void testCloseClosedView() {
 		
 		markersView.open();


### PR DESCRIPTION
Before the view is opened, the viewPart is null, so if the method activate is called, the viewPart, which is null, is used to focus the view and it crashes with NPE. Because of that, viewPart should be checked before the operation is performed, as it is done in method close.
