### PR TITLE
DefaultToolItem does not work with debug buttons

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/WithTooltipTextMatcher.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/matcher/WithTooltipTextMatcher.java
@@ -58,7 +58,7 @@ public class WithTooltipTextMatcher extends AbstractWidgetWithTextMatcher {
 
 	@Override
 	protected boolean matches(String text) {
-		return matcher.matches(text);
+		return matcher.matches(text.replaceAll("&", "").split("\t")[0]);
 	}
 	
 	@Override

--- a/tests/org.jboss.reddeer.swt.test/plugin.xml
+++ b/tests/org.jboss.reddeer.swt.test/plugin.xml
@@ -74,6 +74,13 @@
                   mnemonic="RedDeer SWT WorkbenchToolItem"
                   tooltip="RedDeer SWT WorkbenchToolItem">
             </command>
+            <command
+                  commandId="org.jboss.reddeer.swt.test.command.testCommand"
+                  icon="icons/sample.gif"
+                  id="org.jboss.reddeer.swt.test.toolbars.sampleCommand"
+                  mnemonic="RedDeer SWT Workbench&amp;ToolItem with mnemonic"
+                  tooltip="RedDeer SWT Workbench&amp;ToolItem with mnemonic">
+            </command>
          </toolbar>
       </menuContribution>
    </extension>

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/toolitem/ToolItemTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/toolitem/ToolItemTest.java
@@ -7,6 +7,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
+import org.jboss.reddeer.swt.impl.shell.WorkbenchShell;
 import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
 import org.jboss.reddeer.swt.matcher.RegexMatcher;
 import org.jboss.reddeer.swt.matcher.WithTooltipTextMatcher;
@@ -70,5 +71,11 @@ public class ToolItemTest extends SWTLayerTestCase{
 	public void constructorWithRegexWithReferencedComposite(){
 		DefaultToolItem ti = new DefaultToolItem();
 		System.out.println(ti.getToolTipText());
+	}
+	
+	@Test
+	public void WorkbenchToolItemWithMnemonicTest() {
+		new DefaultToolItem(new WorkbenchShell(), new WithTooltipTextMatcher(
+				"RedDeer SWT WorkbenchToolItem with mnemonic"));
 	}
 }


### PR DESCRIPTION
It affects only debug buttons (_Resume_, _Suspend_, _Terminate_, ...). DefaultToolItem on _Save_, _Run_, ... buttons work fine.

Following testcase IMHO should pass, but it fails.

``` java
import org.jboss.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
import org.jboss.reddeer.junit.runner.RedDeerSuite;
import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
import org.jboss.reddeer.swt.impl.shell.WorkbenchShell;
import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
import org.jboss.reddeer.swt.matcher.RegexMatcher;
import org.jboss.reddeer.swt.matcher.WithTooltipTextMatcher;
import org.junit.Test;
import org.junit.runner.RunWith;

@RunWith(RedDeerSuite.class)
@OpenPerspective(JavaEEPerspective.class)
public class TestClass {

    @Test
    public void testDebugButtons() {

        new DefaultToolItem(new WorkbenchShell(), new WithTooltipTextMatcher(new RegexMatcher("Resume.*")));
    }
}
```
