### PR TITLE
Fix project deletion issue on gnome

### DIFF
--- a/plugins/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
@@ -7,8 +7,10 @@ Bundle-Version: 0.6.0.qualifier
 Bundle-Activator: org.jboss.reddeer.direct.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.common;bundle-version="0.6.0"
+ org.jboss.reddeer.common;bundle-version="0.6.0",
+ org.eclipse.core.resources;bundle-version="3.9.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.direct.platform,
- org.jboss.reddeer.direct.preferences
+ org.jboss.reddeer.direct.preferences,
+ org.jboss.reddeer.direct.project

--- a/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/project/Project.java
+++ b/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/project/Project.java
@@ -1,0 +1,28 @@
+package org.jboss.reddeer.direct.project;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+
+/**
+ * Utils handling project via API
+ * @author vlado pakan
+ *
+ */
+public class Project {
+	/**
+	 * Deletes Eclipse project via Eclipse API
+	 * @param projectName
+	 * @param deleteContent
+	 * @param force
+	 */
+	public static void delete(String projectName, boolean deleteContent , boolean force ){
+		try {
+			ResourcesPlugin.getWorkspace()
+				.getRoot()
+				.getProject(projectName)
+				.delete(deleteContent, force, null);
+		} catch (CoreException ce) {
+			throw new RuntimeException("Unalbe to delete project " + projectName,ce);
+		}
+	}
+}

--- a/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.workbench,
  org.jboss.reddeer.junit;bundle-version="[0.6,0.7)",
  org.eclipse.wst.server.core,
- org.jboss.reddeer.common;bundle-version="[0.6,0.7)"
+ org.jboss.reddeer.common;bundle-version="[0.6,0.7)",
+ org.jboss.reddeer.direct;bundle-version="0.6.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.reddeer.eclipse,
@@ -53,6 +54,7 @@ Export-Package: org.jboss.reddeer.eclipse,
  org.jboss.reddeer.eclipse.ui.views.properties,
  org.jboss.reddeer.eclipse.ui.wizards.datatransfer,
  org.jboss.reddeer.eclipse.ui.wizards.newresource,
+ org.jboss.reddeer.eclipse.utils,
  org.jboss.reddeer.eclipse.wst.common.project.facet.ui,
  org.jboss.reddeer.eclipse.wst.server.ui,
  org.jboss.reddeer.eclipse.wst.server.ui.editor,

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/ide/NewJavaProjectWizardDialog.java
@@ -46,7 +46,7 @@ public class NewJavaProjectWizardDialog extends NewWizardDialog{
 			new WaitUntil(new ShellWithTextIsActive(openAssociatedPerspectiveShellText),
 				TimePeriod.getCustom(20),false);
 			// Try to find open perspective test
-			DefaultShell shell = new DefaultShell(openAssociatedPerspectiveShellText);
+			new DefaultShell(openAssociatedPerspectiveShellText);
 			if (openAssociatedPerspective) {
 				new PushButton("Yes").click();
 			} else {

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/utils/DeleteUtils.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/utils/DeleteUtils.java
@@ -6,6 +6,8 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.jboss.reddeer.common.logging.Logger;
+import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
 import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
@@ -36,6 +38,20 @@ public class DeleteUtils {
 					TimePeriod.VERY_LONG);
 		}
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
+	}
+	/**
+	 * Deletes project via Eclipse API in case deleting via UI calls failed
+	 * @param deleteShellText text of shell
+	 */
+	public static void forceProjectDeletion(Project project , boolean deleteFromFileSystem) {
+		try {
+			project.delete(deleteFromFileSystem);
+		} catch (EclipseLayerException ele) {
+			log.debug("Delete project '" + project.getName() + "' via Eclipse API ");
+			org.jboss.reddeer.direct.project.Project.delete(project.getName(),
+					deleteFromFileSystem, true);
+		}
+		
 	}
 	
 	private static class ShellWithButton extends AbstractShell {

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/cleanworkspace/CleanWorkspaceRequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/cleanworkspace/CleanWorkspaceRequirement.java
@@ -7,6 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.requirement.Requirement;
 import org.jboss.reddeer.requirements.cleanworkspace.CleanWorkspaceRequirement.CleanWorkspace;
 
@@ -60,7 +62,10 @@ public class CleanWorkspaceRequirement implements Requirement<CleanWorkspace> {
 	public void fulfill() {	
 		PackageExplorer packageExplorer = new PackageExplorer();
 		packageExplorer.open();
-		packageExplorer.deleteAllProjects();
+		for (Project project : packageExplorer.getProjects()){
+			DeleteUtils.forceProjectDeletion(project, true);
+		}
+		packageExplorer.activate();
 	}
 
 	/**

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/dialogs/GenerateHashAndEqualsTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/dialogs/GenerateHashAndEqualsTest.java
@@ -8,8 +8,10 @@ import org.jboss.reddeer.eclipse.jdt.ui.NewJavaClassWizardPage;
 import org.jboss.reddeer.eclipse.jdt.ui.dialogs.GenerateHashCodeEqualsDialog;
 import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardDialog;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.requirements.cleanworkspace.CleanWorkspaceRequirement.CleanWorkspace;
+import org.jboss.reddeer.swt.impl.shell.WorkbenchShell;
 import org.jboss.reddeer.workbench.impl.editor.TextEditor;
 import org.junit.AfterClass;
 import org.junit.Test;
@@ -22,11 +24,13 @@ public class GenerateHashAndEqualsTest {
 	@AfterClass
 	public static void deleteProject(){
 		PackageExplorer pe = new PackageExplorer();
-		pe.getProject("GenHashProject").delete(true);
+		pe.open();
+		DeleteUtils.forceProjectDeletion(pe.getProject("GenHashProject"),true);
 	}
 	
 	@Test
 	public void generateHashAndEquals(){
+		new WorkbenchShell().maximize();
 		NewJavaProjectWizardDialog jp = new NewJavaProjectWizardDialog();
 		jp.open();
 		jp.getFirstPage().setProjectName("GenHashProject");

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/packageexplorer/PackageExplorerTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/packageexplorer/PackageExplorerTest.java
@@ -7,6 +7,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardDialog;
 import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardPage;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.handler.WorkbenchHandler;
 import org.junit.After;
@@ -110,16 +111,16 @@ public class PackageExplorerTest {
 	public void tearDown() {
 		if (packageExplorer != null){
 			if (packageExplorer.containsProject(PackageExplorerTest.PROJECT_NAME_0)) {
-				packageExplorer.getProject(PackageExplorerTest.PROJECT_NAME_0)
-						.delete(true);
+				DeleteUtils.forceProjectDeletion(packageExplorer.getProject(PackageExplorerTest.PROJECT_NAME_0),
+					true);
 			}
 			if (packageExplorer.containsProject(PackageExplorerTest.PROJECT_NAME_1)) {
-				packageExplorer.getProject(PackageExplorerTest.PROJECT_NAME_1)
-						.delete(true);
+				DeleteUtils.forceProjectDeletion(packageExplorer.getProject(PackageExplorerTest.PROJECT_NAME_1),
+					true);
 			}
 			if (packageExplorer.containsProject(PackageExplorerTest.PROJECT_NAME_2)) {
-				packageExplorer.getProject(PackageExplorerTest.PROJECT_NAME_2)
-						.delete(true);
+				DeleteUtils.forceProjectDeletion(packageExplorer.getProject(PackageExplorerTest.PROJECT_NAME_2),
+					true);
 			}
 		}
 	}

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/packageexplorer/ProjectItemTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/packageexplorer/ProjectItemTest.java
@@ -17,6 +17,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.jboss.reddeer.eclipse.ui.ide.NewFileCreationWizardDialog;
 import org.jboss.reddeer.eclipse.ui.ide.NewFileCreationWizardPage;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaPerspective;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
@@ -187,7 +188,7 @@ public class ProjectItemTest {
 	public void tearDown() {
 		packageExplorer.close();
 		packageExplorer.open();
-		packageExplorer.getProject(ProjectItemTest.PROJECT_NAME).delete(true);
+		DeleteUtils.forceProjectDeletion(packageExplorer.getProject(ProjectItemTest.PROJECT_NAME),true);
 	}
 	
 	private class NewFileCreationWizard extends NewFileCreationWizardPage {

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/packageexplorer/ProjectTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/packageexplorer/ProjectTest.java
@@ -8,6 +8,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardPage;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaPerspective;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.junit.After;
@@ -76,13 +77,16 @@ public class ProjectTest {
 		packageExplorer.close();
 		packageExplorer.open();
 		if (packageExplorer.containsProject(ProjectTest.PROJECT_NAME_0)) {
-			packageExplorer.getProject(ProjectTest.PROJECT_NAME_0).delete(true);
+			DeleteUtils.forceProjectDeletion(packageExplorer.getProject(ProjectTest.PROJECT_NAME_0),
+				true);
 		}
 		if (packageExplorer.containsProject(ProjectTest.PROJECT_NAME_1)) {
-			packageExplorer.getProject(ProjectTest.PROJECT_NAME_1).delete(true);
+			DeleteUtils.forceProjectDeletion(packageExplorer.getProject(ProjectTest.PROJECT_NAME_1),
+				true);
 		}
 		if (packageExplorer.containsProject(ProjectTest.PROJECT_NAME_2)) {
-			packageExplorer.getProject(ProjectTest.PROJECT_NAME_2).delete(true);
+			DeleteUtils.forceProjectDeletion(packageExplorer.getProject(ProjectTest.PROJECT_NAME_2),
+				true);
 		}
 	}
 }

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jst/ejb/ui/EjbWizardTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jst/ejb/ui/EjbWizardTest.java
@@ -11,6 +11,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
 import org.jboss.reddeer.eclipse.jst.ejb.ui.*;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 
 @RunWith(RedDeerSuite.class)
 @OpenPerspective(JavaEEPerspective.class)
@@ -21,7 +22,7 @@ public class EjbWizardTest {
 		PackageExplorer pe = new PackageExplorer();
 		pe.open();
 		for(Project p: pe.getProjects()){
-			p.delete(true);
+			DeleteUtils.forceProjectDeletion(p,true);
 		}
 	}
     

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/console/ConsoleViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/console/ConsoleViewTest.java
@@ -14,6 +14,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardPage;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaPerspective;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.jboss.reddeer.swt.api.StyledText;
@@ -48,7 +49,7 @@ public class ConsoleViewTest {
 	
 	@AfterClass
 	public static void tearDownClass() {
-		new PackageExplorer().getProject(TEST_PROJECT_NAME).delete(true);
+		DeleteUtils.forceProjectDeletion(new PackageExplorer().getProject(TEST_PROJECT_NAME),true);
 	}
 	
 	@Before

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/dialogs/ProjectPropertyPageTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/dialogs/ProjectPropertyPageTest.java
@@ -8,6 +8,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardPage;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
 import org.jboss.reddeer.eclipse.ui.dialogs.ProjectPropertyPage;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.api.Shell;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
@@ -48,7 +49,7 @@ public class ProjectPropertyPageTest {
 			// not found, no action needed
 		}
 		
-		project.delete(true);
+		DeleteUtils.forceProjectDeletion(project,true);
 	}
 	
 	@Test

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/problems/ProblemsViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/problems/ProblemsViewTest.java
@@ -15,6 +15,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardDialog;
 import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardPage;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.problems.ProblemsView;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
@@ -68,7 +69,7 @@ public class ProblemsViewTest {
 	@After
 	public void tearDown() {
 		pkgExplorer.open();
-		pkgExplorer.getProject(PROJECT_NAME).delete(true);
+		DeleteUtils.forceProjectDeletion(pkgExplorer.getProject(PROJECT_NAME),true);
 	}
 	
 	@Test

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/contentoutline/OutlineViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/contentoutline/OutlineViewTest.java
@@ -9,6 +9,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardDialog;
 import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardPage;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.views.contentoutline.OutlineView;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.handler.WorkbenchHandler;
@@ -32,7 +33,7 @@ public class OutlineViewTest{
 	
 	@AfterClass
 	public static void cleanup() {
-		packageExplorer.getProject(TEST_PROJECT_NAME).delete(true);
+		DeleteUtils.forceProjectDeletion(packageExplorer.getProject(TEST_PROJECT_NAME),true);
 	}
 	
 	@Test

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/navigator/ResourceNavigatorTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/navigator/ResourceNavigatorTest.java
@@ -8,6 +8,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardDialog;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.jboss.reddeer.eclipse.ui.views.navigator.ResourceNavigator;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.handler.WorkbenchHandler;
 import org.junit.After;
@@ -95,7 +96,7 @@ public class ResourceNavigatorTest {
 	public void tearDown() {
 		if (navigator != null){
 			if(navigator.containsProject(PROJECT_NAME)) {
-				navigator.getProject(PROJECT_NAME).delete(true);
+				DeleteUtils.forceProjectDeletion(navigator.getProject(PROJECT_NAME),true);
 			}
 		}
 	}

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/properties/PropertiesViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/properties/PropertiesViewTest.java
@@ -11,6 +11,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.ide.NewJavaProjectWizardPage;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesViewProperty;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.junit.After;
@@ -88,8 +89,8 @@ public class PropertiesViewTest {
 	public void tearDown() {
 		PackageExplorer packageExplorer = new PackageExplorer();
 		if (packageExplorer.containsProject(PropertiesViewTest.TEST_PROJECT_NAME)) {
-			packageExplorer.getProject(PropertiesViewTest.TEST_PROJECT_NAME)
-					.delete(true);
+			DeleteUtils.forceProjectDeletion(packageExplorer.getProject(PropertiesViewTest.TEST_PROJECT_NAME),
+				true);
 		}
 	}
 	

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/wizards/newresource/BasicNewProjectResourceWizardTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/wizards/newresource/BasicNewProjectResourceWizardTest.java
@@ -9,6 +9,7 @@ import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.dialogs.WizardNewProjectCreationPage;
 import org.jboss.reddeer.eclipse.ui.dialogs.WizardNewProjectReferencePage;
 import org.jboss.reddeer.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.junit.After;
 import org.junit.Before;
@@ -90,14 +91,14 @@ public class BasicNewProjectResourceWizardTest {
 	@After
 	public void tearDown() {
 		if (packageExplorer.containsProject(BasicNewProjectResourceWizardTest.CUSTOMIZED_PROJECT_NAME)){
-			packageExplorer.getProject(
-					BasicNewProjectResourceWizardTest.CUSTOMIZED_PROJECT_NAME)
-					.delete(true);
+			DeleteUtils.forceProjectDeletion(packageExplorer.getProject(
+					BasicNewProjectResourceWizardTest.CUSTOMIZED_PROJECT_NAME),
+				true);
 		}
 		if (packageExplorer.containsProject(BasicNewProjectResourceWizardTest.DEFAULT_PROJECT_NAME)){
-			packageExplorer.getProject(
-					BasicNewProjectResourceWizardTest.DEFAULT_PROJECT_NAME).delete(
-					true);
+			DeleteUtils.forceProjectDeletion(packageExplorer.getProject(
+					BasicNewProjectResourceWizardTest.DEFAULT_PROJECT_NAME),
+				true);
 		}
 		File customProjectDir = new File(
 				BasicNewProjectResourceWizardTest.CUSTOM_PROJECT_LOCATION);

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ModifyModulesDialogTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ModifyModulesDialogTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.Server;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.ServerModule;
 import org.jboss.reddeer.eclipse.wst.server.ui.wizard.ModifyModulesDialog;
@@ -34,8 +35,9 @@ public class ModifyModulesDialogTest extends ServersViewTestCase{
 	@AfterClass
 	public static void removeProjects(){
 		PackageExplorer explorer = new PackageExplorer();
+		explorer.open();
 		for (Project project : explorer.getProjects()){
-			project.delete(true);
+			DeleteUtils.forceProjectDeletion(project, true);
 		}
 	}
 	

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ServerTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ServerTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.eclipse.wst.server.ui.editor.ServerEditor;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.Server;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.ServerModule;
@@ -43,8 +44,9 @@ public class ServerTest extends ServersViewTestCase {
 	@AfterClass
 	public static void removeProjects(){
 		PackageExplorer explorer = new PackageExplorer();
+		explorer.open();
 		for (Project project : explorer.getProjects()){
-			project.delete(true);
+			DeleteUtils.forceProjectDeletion(project,true);
 		}
 	}
 	

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/wst/common/project/facet/ui/RuntimesPropertyPageTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/wst/common/project/facet/ui/RuntimesPropertyPageTest.java
@@ -8,6 +8,7 @@ import org.jboss.reddeer.eclipse.test.wst.server.ui.TestServerRuntime;
 import org.jboss.reddeer.eclipse.test.wst.server.ui.view.ServersViewTestCase;
 import org.jboss.reddeer.eclipse.ui.wizards.datatransfer.ExternalProjectImportWizardDialog;
 import org.jboss.reddeer.eclipse.ui.wizards.datatransfer.WizardProjectsImportPage;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.eclipse.wst.server.ui.RuntimePreferencePage;
 import org.jboss.reddeer.eclipse.wst.server.ui.wizard.NewRuntimeWizardDialog;
 import org.jboss.reddeer.eclipse.wst.server.ui.wizard.NewRuntimeWizardPage;
@@ -64,7 +65,7 @@ public class RuntimesPropertyPageTest {
 			// not found, no action needed
 		}
 		
-		new PackageExplorer().getProject(PROJECT).delete(true);
+		DeleteUtils.forceProjectDeletion(new PackageExplorer().getProject(PROJECT),true);
 		
 		RuntimePreferencePage runtimePreference = new RuntimePreferencePage();
 		runtimePreference.open();

--- a/tests/org.jboss.reddeer.gef.test/src/org/jboss/reddeer/gef/test/EditPartTest.java
+++ b/tests/org.jboss.reddeer.gef.test/src/org/jboss/reddeer/gef/test/EditPartTest.java
@@ -1,6 +1,7 @@
 package org.jboss.reddeer.gef.test;
 
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.gef.GEFLayerException;
 import org.jboss.reddeer.gef.editor.GEFEditor;
 import org.jboss.reddeer.gef.impl.connection.DefaultConnection;
@@ -42,7 +43,7 @@ public class EditPartTest {
 		new GEFEditor().close();
 		ProjectExplorer projectExplorer = new ProjectExplorer();
 		projectExplorer.open();
-		projectExplorer.getProject(PROJECT_NAME).delete(true);
+		DeleteUtils.forceProjectDeletion(projectExplorer.getProject(PROJECT_NAME),true);
 	}
 
 	@Test

--- a/tests/org.jboss.reddeer.gef.test/src/org/jboss/reddeer/gef/test/GEFEditorTest.java
+++ b/tests/org.jboss.reddeer.gef.test/src/org/jboss/reddeer/gef/test/GEFEditorTest.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.gef.editor.GEFEditor;
 import org.jboss.reddeer.gef.test.wizard.ExampleWizard;
 import org.jboss.reddeer.gef.test.wizard.GeneralProjectWizard;
@@ -36,7 +37,7 @@ public class GEFEditorTest {
 		new GEFEditor().close();
 		ProjectExplorer projectExplorer = new ProjectExplorer();
 		projectExplorer.open();
-		projectExplorer.getProject(PROJECT_NAME).delete(true);
+		DeleteUtils.forceProjectDeletion(projectExplorer.getProject(PROJECT_NAME),true);
 	}
 
 	@Test

--- a/tests/org.jboss.reddeer.graphiti.test/src/org/jboss/reddeer/graphiti/test/LabeledGraphitiEditPartTest.java
+++ b/tests/org.jboss.reddeer.graphiti.test/src/org/jboss/reddeer/graphiti/test/LabeledGraphitiEditPartTest.java
@@ -2,6 +2,7 @@ package org.jboss.reddeer.graphiti.test;
 
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
 import org.jboss.reddeer.eclipse.jface.wizard.NewWizardDialog;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.gef.GEFLayerException;
 import org.jboss.reddeer.gef.editor.GEFEditor;
 import org.jboss.reddeer.graphiti.impl.graphitieditpart.LabeledGraphitiEditPart;
@@ -40,7 +41,7 @@ public class LabeledGraphitiEditPartTest {
 		new GEFEditor().close();
 		ProjectExplorer projectExplorer = new ProjectExplorer();
 		projectExplorer.open();
-		projectExplorer.getProject(PROJECT_NAME).delete(true);
+		DeleteUtils.forceProjectDeletion(projectExplorer.getProject(PROJECT_NAME),true);
 	}
 
 	@Test(expected = GEFLayerException.class)

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/EditorBarTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/EditorBarTest.java
@@ -3,6 +3,7 @@ package org.jboss.reddeer.swt.test;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
 import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
@@ -60,7 +61,7 @@ public class EditorBarTest {
 	public void deleteProject(){
 		ProjectExplorer pe = new ProjectExplorer();
 		pe.open();
-		pe.getProject(projectName).delete(true);
+		DeleteUtils.forceProjectDeletion(pe.getProject(projectName),true);
 	}
 
 	@Test 

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/menu/ContextMenuTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/menu/ContextMenuTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
@@ -56,7 +57,7 @@ public class ContextMenuTest {
 	public static void deleteProject(){
 		ProjectExplorer pe = new ProjectExplorer();
 		pe.open();
-		pe.getProject(projectName).delete(true);;
+		DeleteUtils.forceProjectDeletion(pe.getProject(projectName),true);
 	}
 	
 	@Test(expected=SWTLayerException.class)

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/EditorTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/EditorTest.java
@@ -15,6 +15,7 @@ import org.jboss.reddeer.eclipse.ui.ide.NewFileCreationWizardDialog;
 import org.jboss.reddeer.eclipse.ui.ide.NewFileCreationWizardPage;
 import org.jboss.reddeer.eclipse.ui.problems.ProblemsView;
 import org.jboss.reddeer.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.workbench.api.Editor;
@@ -73,7 +74,7 @@ public class EditorTest {
 	public static void teardownClass(){
 		List<Project> projects = new ProjectExplorer().getProjects();
 		for (Project p: projects){
-			p.delete(true);
+			DeleteUtils.forceProjectDeletion(p,true);
 		}
 	}
 

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
@@ -25,6 +25,7 @@ import org.jboss.reddeer.eclipse.ui.ide.NewFileCreationWizardDialog;
 import org.jboss.reddeer.eclipse.ui.ide.NewFileCreationWizardPage;
 import org.jboss.reddeer.eclipse.ui.wizards.datatransfer.ExternalProjectImportWizardDialog;
 import org.jboss.reddeer.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
+import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.handler.ShellHandler;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
@@ -55,7 +56,7 @@ public class TextEditorTest {
 	public static void teardownClass(){
 		ProjectExplorer pe = new ProjectExplorer();
 		for (Project p : pe.getProjects()){
-			p.delete(true);
+			DeleteUtils.forceProjectDeletion(p,true);
 		}
 	}
 


### PR DESCRIPTION
Because of not fixed Eclipse issue now Reddeer will try to delete project item via Context menu then via ShellMenu and finally via Eclipse API.

Deleting via Eclipse API will be used only in tear down methods because in test methods forced deleting  of project via Eclipse API is assumed as Failure
