### PR TITLE
LabeledGraphitiEditPartTest.doubleClickTest: widget not found

### DIFF
--- a/plugins/org.jboss.reddeer.gef/src/org/jboss/reddeer/gef/handler/EditPartHandler.java
+++ b/plugins/org.jboss.reddeer.gef/src/org/jboss/reddeer/gef/handler/EditPartHandler.java
@@ -37,7 +37,7 @@ public class EditPartHandler {
 	 *            Edit part
 	 */
 	public void select(final EditPart editPart) {
-		Display.getDisplay().syncExec(new Runnable() {
+		Display.syncExec(new Runnable() {
 			@Override
 			public void run() {
 				editPart.getViewer().select(editPart);
@@ -52,11 +52,17 @@ public class EditPartHandler {
 	 *            Edit part
 	 */
 	public void directEdit(final EditPart editPart) {
-		Display.getDisplay().syncExec(new Runnable() {
+		Display.asyncExec(new Runnable() {
 			@Override
 			public void run() {
 				DirectEditRequest request = new DirectEditRequest();
 				editPart.performRequest(request);
+			}
+		});
+		Display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				
 			}
 		});
 	}


### PR DESCRIPTION
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
    at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:206)
    at org.jboss.reddeer.swt.lookup.TextLookup.getText(TextLookup.java:36)
    at org.jboss.reddeer.swt.impl.text.DefaultText.<init>(DefaultText.java:30)
    at org.jboss.reddeer.gef.impl.editpart.AbstractEditPart.setLabel(AbstractEditPart.java:76)
    at org.jboss.reddeer.graphiti.test.LabeledGraphitiEditPartTest.doubleClickTest(LabeledGraphitiEditPartTest.java:62)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner$InvokeMethodWithException.evaluate(RequirementsRunner.java:291)
    at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:48)
    at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:43)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:48)
    at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:111)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
    at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
    at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:86)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
    at java.lang.Thread.run(Thread.java:722)
Caused by: org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: org.jboss.reddeer.swt.wait.TimePeriod@177a28db ms.: widget is found
    at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:147)
    at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:100)
    at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:69)
    at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
    at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
    at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
    at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:199)
    ... 57 more
