### PR TITLE
foo.bar.myplugin.luna.reddeer.test.BasicTest.test default failing

### DIFF
--- a/archetype/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/archetype/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Bundle-RequiredExecutionEnvironment: J2SE-1.5,
 Require-Bundle: org.junit,
  org.eclipse.ui,
  org.eclipse.core.runtime,
+ org.eclipse.equinox.event,
  org.hamcrest.core,
  org.jboss.reddeer.junit${rd_version},
  org.jboss.reddeer.swt${rd_version}

--- a/archetype/src/main/resources/archetype-resources/src/reddeer/test/BasicTest.java
+++ b/archetype/src/main/resources/archetype-resources/src/reddeer/test/BasicTest.java
@@ -4,10 +4,8 @@
 package ${package}.reddeer.test;
 
 import static org.junit.Assert.assertTrue;
-
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.junit.Test;
-
 
 public class BasicTest {
 	

--- a/archetype/src/test/resources/projects/jboss-reddeer-archetype/archetype.properties
+++ b/archetype/src/test/resources/projects/jboss-reddeer-archetype/archetype.properties
@@ -2,6 +2,6 @@ package=foo.bar.myplugin.luna
 version=1.0.0-SNAPSHOT
 groupId=foo.bar.myplugin
 artifactId=luna
-tycho_version=0.18.1
+tycho_version=0.21.0
 eclipse_platform=luna
 reddeer_version=master


### PR DESCRIPTION
see RedDeer_master_matrix/jdk=sunjdk1.7,label=winos7_32b/340/testReport/junit/foo.bar.myplugin.luna.reddeer.test/BasicTest/test_default/?

Error Message

SWT Shell passed to constructor is null

Stacktrace

org.jboss.reddeer.swt.exception.SWTLayerException: SWT Shell passed to constructor is null
    at org.jboss.reddeer.swt.impl.shell.AbstractShell.<init>(AbstractShell.java:33)
    at org.jboss.reddeer.swt.impl.shell.DefaultShell.<init>(DefaultShell.java:26)
    at foo.bar.myplugin.luna.reddeer.test.BasicTest.test(BasicTest.java:13)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner$InvokeMethodWithException.evaluate(RequirementsRunner.java:275)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:112)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
    at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
    at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:85)
    at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
    at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
    at java.lang.Thread.run(Thread.java:722)
