### PR TITLE
Add nexus deployment settings for staging

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -37,6 +37,12 @@
 			<url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
 			<uniqueVersion>false</uniqueVersion>
 		</snapshotRepository>
+		<repository>
+			<id>jboss-staging-repository</id>
+			<name>JBoss Staging Service</name>
+			<uniqueVersion>false</uniqueVersion>
+			<url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
+		</repository>
 	</distributionManagement>
 
 </project>


### PR DESCRIPTION
Previously we only added the settings for snapshots, so when I was
trying to release RedDeer 0.6.0, the deploy command failed.
This should fix it. The definition is copied from the jbosstools
parent pom.
