### PR TITLE
Fix for the previous commit - nexus id was wrong

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -38,7 +38,7 @@
 			<uniqueVersion>false</uniqueVersion>
 		</snapshotRepository>
 		<repository>
-			<id>jboss-staging-repository</id>
+			<id>jboss-releases-repository</id>
 			<name>JBoss Staging Service</name>
 			<uniqueVersion>false</uniqueVersion>
 			<url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>


### PR DESCRIPTION
The nexus id for the staging repo should be
jboss-releases-repository and not
jboss-staging-repository. Otherwise it won't match
the one in jenkins settings.xml
