### PR TITLE
Fix screenshot issues

### DIFF
--- a/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/after/test/impl/CloseAllShellsExt.java
+++ b/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/after/test/impl/CloseAllShellsExt.java
@@ -67,11 +67,15 @@ public class CloseAllShellsExt implements IAfterTest {
 			
 			closedShellsTitles.add(shellTitle);
 			try {
-				String canonicalName = null;
-				if (target != null) {
-					canonicalName = target.getClass().getCanonicalName();
-				}
-				new CaptureScreenshot().captureScreenshot(canonicalName + "-" + shellTitle);
+				String fileName;
+				if (target == null) {
+        			fileName = "UnknownTestClass@CloseAllShellsExt#" + shellTitle;
+        		} else {
+        			fileName = target.getClass().getSimpleName()
+        					+ "@CloseAllShellsExt#" + shellTitle + "["
+        					+ target.getClass().getPackage().getName() + "]";
+        		}
+				new CaptureScreenshot().captureScreenshot(null, fileName);
 			} catch (CaptureScreenshotException e) {
 				e.printStackTrace();
 			}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RunAfters.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RunAfters.java
@@ -10,7 +10,14 @@ import org.jboss.reddeer.common.logging.Logger;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
 
+/**
+ * Statement which run after tests or classes. Upon failure a screenshot is captured.
+ * 
+ * @author mlabuda@redhat.com
+ *
+ */
 public class RunAfters extends Statement {
     private final Statement fNext;
 
@@ -18,22 +25,35 @@ public class RunAfters extends Statement {
 
     private final List<FrameworkMethod> fAfters;
     
+    private final FrameworkMethod fMethod;
+    
+    private TestClass testClass;
+    
     private static final Logger log = Logger.getLogger(RequirementsRunner.class);
+    
+    private String config;
     
     private List<IAfterTest> afterTests;
 
-    public RunAfters(Statement next, List<FrameworkMethod> afters, Object target) {
-        this(next, afters, target, null);
+    public RunAfters(String config, FrameworkMethod method, Statement next, List<FrameworkMethod> afters, 
+    		Object target, TestClass testClass) {
+        this(config, method, next, afters, target, null, testClass);
     }
     
-    public RunAfters(Statement next, List<FrameworkMethod> afters, Object target, List<IAfterTest> afterTests) {
+    public RunAfters(String config, FrameworkMethod method, Statement next, List<FrameworkMethod> afters, 
+    		Object target, List<IAfterTest> afterTests, TestClass testClass) {
         fNext = next;
         fAfters = afters;
         fTarget = target;
+        fMethod = method;
         this.afterTests = new ArrayList<IAfterTest>();
         if(afterTests != null) {
         	this.afterTests = afterTests;
         }
+        if (testClass != null) {
+        	this.testClass = testClass;
+        }
+        this.config = config;
     }
 
     @Override
@@ -50,11 +70,21 @@ public class RunAfters extends Statement {
                 } catch (Throwable e) {
                 	CaptureScreenshot capturer = new CaptureScreenshot();
                 	try {
-        				String canonicalName = "";
-        				if (fTarget != null) {
-        					canonicalName = fTarget.getClass().getCanonicalName();
-        				}
-                		capturer.captureScreenshot(canonicalName + "-" + each.getName()); 
+                		String methodName = "";
+                		if (fMethod != null) {
+                			methodName = "#" + fMethod.getName();
+                		}
+                		String fileName;
+                		if (fTarget == null) {
+                			fileName = testClass.getJavaClass().getSimpleName()
+                					+ "@AfterClass#" + each.getName() + "["
+                					+ testClass.getJavaClass().getPackage().getName() + "]";
+                		} else {
+                			fileName = fTarget.getClass().getSimpleName() 
+                				+ methodName + "@After#" + each.getName()
+        						+ "[" + fTarget.getClass().getPackage().getName() + "]";
+                		}
+        				capturer.captureScreenshot(config, fileName);
                 	} catch (CaptureScreenshotException ex) {
                 		ex.printInfo(log);
                 	}
@@ -66,7 +96,26 @@ public class RunAfters extends Statement {
                 	afterTest.runAfterTest(fTarget);
                 } catch (Throwable e) {
                 	CaptureScreenshot capturer = new CaptureScreenshot();
-                	capturer.captureScreenshot(afterTest.getClass().getCanonicalName() + "-runAfterTest");
+                	try {
+                		String methodName = "";
+                		if (fMethod != null) {
+                			methodName = "#" + fMethod.getName();
+                		}
+                		String fileName;
+                		if (fTarget == null) {
+                			fileName = testClass.getJavaClass().getSimpleName()
+                					+ "@IAfter#" + afterTest.getClass().getCanonicalName()
+                					+ "[" + testClass.getJavaClass().getPackage().getName() + "]";
+                		} else {
+                			fileName = fTarget.getClass().getSimpleName() 
+                					+ methodName + "@IAfter#" 
+                					+ afterTest.getClass().getCanonicalName()
+                					+ "[" + fTarget.getClass().getPackage().getName() + "]";
+                		}
+        				capturer.captureScreenshot(config, fileName);
+                	} catch (CaptureScreenshotException ex) {
+                		ex.printInfo(log);
+                	}
                     errors.add(e);
                 }
             }

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RunBefores.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RunBefores.java
@@ -2,26 +2,43 @@ package org.jboss.reddeer.junit.internal.runner;
 
 import java.util.List;
 
+import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.junit.internal.screenshot.CaptureScreenshot;
 import org.jboss.reddeer.junit.internal.screenshot.CaptureScreenshotException;
-import org.jboss.reddeer.common.logging.Logger;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
 
+/**
+ * 
+ * Statement which run before tests or classes. Upon failure a screenshot is captured.
+ * 
+ * @author mlabuda@redhat.com
+ *
+ */
 public class RunBefores extends Statement {
 	private final Statement fNext;
 
 	private final Object fTarget;
 
 	private final List<FrameworkMethod> fBefores;
+	
+	private final FrameworkMethod fMethod;
+	
+	private TestClass testClass;
+	
+	private String config;
 
 	private static final Logger log = Logger.getLogger(RequirementsRunner.class);
 	
-	public RunBefores(Statement next, List<FrameworkMethod> befores,
-			Object target) {
+	public RunBefores(String config, FrameworkMethod method, Statement next, List<FrameworkMethod> befores,
+			Object target, TestClass testClass) {
 		fNext = next;
 		fBefores = befores;
 		fTarget = target;
+		fMethod = method;
+		this.testClass = testClass;
+		this.config = config;
 	}
 
 	@Override
@@ -33,13 +50,26 @@ public class RunBefores extends Statement {
 				before.invokeExplosively(fTarget);
 			}
 		} catch (Throwable throwable) {
+						
 			CaptureScreenshot capturer = new CaptureScreenshot();
 			try {
-				String canonicalName = "";
-				if (fTarget != null) {
-					canonicalName = fTarget.getClass().getCanonicalName();
-				}
-				capturer.captureScreenshot(canonicalName + "-" + before.getName());
+				String methodName = "";
+        		if (fMethod != null) {
+        			methodName = "#" + fMethod.getName();
+        		}
+        		String fileName;
+        		if (fTarget == null) {
+        			fileName = testClass.getJavaClass().getSimpleName()
+        					+ "@BeforeClass#" + before.getName() + "["
+        					+ testClass.getJavaClass().getPackage().getName() + "]";
+        		} else {
+        			fileName = fTarget.getClass().getSimpleName() 
+        				+ methodName + "@Before#" + before.getName()
+						+ "[" + fTarget.getClass().getPackage().getName() + "]";
+        		}
+				capturer.captureScreenshot(config, fileName);
+				
+				
 			} catch (CaptureScreenshotException ex) {
 				ex.printInfo(log);
 			}


### PR DESCRIPTION
This file name is not good for a screenshot file ./target/screenshots/org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt-runAfterTest.png. It probably can get overwritten by many failing tests. Screenshot file should contain name of failed test

See master job RedDeer_master_matrix/jdk=sunjdk1.7,label=fenix/322/consoleText

It seems to create too many screenshots for one test fail but I'm not absolutely sure about it. Please check it.

Screenshots has to be created also for failures in BeforeClass a AfterClass methods.

Do not overwrite screen shots files generate unique file names instead
