### PR TITLE
Increased timeout of Eclipse tests to 2 hours

### DIFF
--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<properties>
-		<surefire.timeout>5400</surefire.timeout>
+		<surefire.timeout>7200</surefire.timeout>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
The eclipse tests reached the previous limit again (90 min),
so I'm increasing the timeout again, to 2 hours.
