### PR TITLE
Need to update TaskRepositoriesView.java to handle secure storage dialog in JBDS

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
@@ -67,6 +67,16 @@ public class TaskRepositoriesView extends WorkbenchView {
 		new PushButton("Finish").click();	
 	}
 	
+	/* Added October 2014 - running on JBDS results in Secure Storage Dialog being opened */
+	public void closeSecureStorage () {
+		// On Linux Secure Storage shell is opened
+		try{
+			new DefaultShell("Secure Storage Password").close();
+		} catch (SWTLayerException swtle){
+			// do nothing shell was not opened
+		}	
+	}
+	
 	/**
 	 * Activates a task with a given name.
 	 * 


### PR DESCRIPTION
The file to change is:
plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java

The change is identical to that made here:

https://github.com/jboss-reddeer/reddeer/commit/a6be98ab554119d96c3125793c8db595a5d9bc08
