### PR TITLE
View methods should expect the same prerequisites

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/view/DataSourceExplorer.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/ui/view/DataSourceExplorer.java
@@ -30,7 +30,6 @@ public class DataSourceExplorer extends WorkbenchView {
 	 * @return List of database connections
 	 */
 	public List<String> getDatabaseConnections() {
-		open();
 		return getItems("Database Connections");
 	}
 
@@ -40,7 +39,6 @@ public class DataSourceExplorer extends WorkbenchView {
 	 * @return List of flat file data sources
 	 */
 	public List<String> getFlatFileDataSources() {
-		open();
 		return getItems("ODA Data Sources", "Flat File Data Source");
 	}
 
@@ -50,7 +48,6 @@ public class DataSourceExplorer extends WorkbenchView {
 	 * @return List of web service data sources
 	 */
 	public List<String> getWebServiceDataSources() {
-		open();
 		return getItems("ODA Data Sources", "Web Service Data Source");
 	}
 
@@ -60,11 +57,11 @@ public class DataSourceExplorer extends WorkbenchView {
 	 * @return List of xml data sources
 	 */
 	public List<String> getXmlDataSources() {
-		open();
 		return getItems("ODA Data Sources", "XML Data Source");
 	}
 
 	protected List<String> getItems(String... path) {
+		activate();
 		TreeItem root = new DefaultTreeItem(path);
 		List<String> list = new ArrayList<String>();
 		for (TreeItem treeItem : root.getItems()) {

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/AbstractExplorer.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/AbstractExplorer.java
@@ -35,7 +35,6 @@ public class AbstractExplorer extends WorkbenchView {
 	 * @param projectName
 	 */
 	public void selectProjects(String... projectName){
-		
 		ArrayList<TreeItem> selectTreeItems = new ArrayList<TreeItem>();
 		for(String pname: projectName){
 			selectTreeItems.add(getProject(pname).getTreeItem()); //check if project exists
@@ -97,6 +96,7 @@ public class AbstractExplorer extends WorkbenchView {
 	 * @param deleteFromFileSystem true if project should be deleted from file system, false otherwise
 	 */
 	public void deleteAllProjects(boolean deleteFromFileSystem){
+		activate();
 		if(getProjects().size() > 0){
 			selectAllProjects();
 			new ContextMenu("Refresh").select();
@@ -112,7 +112,7 @@ public class AbstractExplorer extends WorkbenchView {
 	}
 
 	private DefaultTree getTree(){
-		open();
+		activate();
 		return new DefaultTree();
 	}
 		
@@ -122,6 +122,7 @@ public class AbstractExplorer extends WorkbenchView {
 	 * @return project instance
 	 */
 	public Project getProject(String projectName){
+		activate();
 		for (Project project : getProjects()){
 			if (project.getName().equals(projectName)){
 				return project;

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/junit/JUnitView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/jdt/ui/junit/JUnitView.java
@@ -26,6 +26,7 @@ public class JUnitView extends WorkbenchView {
 	 * @return run status
 	 */
 	public String getRunStatus() {
+		activate();
 		return new LabeledText("Runs: ").getText().trim();
 	}
 
@@ -35,6 +36,7 @@ public class JUnitView extends WorkbenchView {
 	 * @return number of errors
 	 */
 	public int getNumberOfErrors() {
+		activate();
 		String errorStatus = new LabeledText("Errors: ").getText().trim();
 		return Integer.valueOf(errorStatus);
 	}
@@ -45,6 +47,7 @@ public class JUnitView extends WorkbenchView {
 	 * @return number of failures
 	 */
 	public int getNumberOfFailures() {
+		activate();
 		String errorStatus = new LabeledText("Failures: ").getText().trim();
 		return Integer.valueOf(errorStatus);
 	}
@@ -55,6 +58,7 @@ public class JUnitView extends WorkbenchView {
 	 * @return view status
 	 */
 	public String getViewStatus() {
+		activate();
 		return new DefaultLabel().getText().trim();
 	}
 }

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskListView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskListView.java
@@ -38,10 +38,11 @@ public class TaskListView extends WorkbenchView {
 	 * 
 	 * @return List of task lists
 	 */
-	public List<TaskList> getTaskLists(){
+	public List<TaskList> getTaskLists(){		
 		List<TaskList> theTaskLists = new ArrayList<TaskList>();
-
 		Tree tree;
+		
+		activate();
 		try {
 			tree = new DefaultTree();
 		} catch (SWTLayerException e){
@@ -60,6 +61,7 @@ public class TaskListView extends WorkbenchView {
 	 * @return Task list
 	 */
 	public TaskList getTaskList(String name){
+		activate();
 		for (TaskList repository : getTaskLists()){
 			if (repository.getName().equals(name)){
 				return repository;
@@ -69,7 +71,7 @@ public class TaskListView extends WorkbenchView {
 	}
 
 	protected Tree getRepositoriesTree(){
-		open();
+		activate();
 		return new DefaultTree();
 	}
 	
@@ -81,6 +83,7 @@ public class TaskListView extends WorkbenchView {
 	 * @return Task as a tree item
 	 */
 	public TreeItem getTask (String taskCategory, String taskName) {
+		activate();
 		new DefaultTree();
 		
 		DefaultTreeItem theCategory = new DefaultTreeItem (taskCategory);		
@@ -94,6 +97,7 @@ public class TaskListView extends WorkbenchView {
 	/* For use in the Task List View */
 	public void createLocalTaskTest () {
 				
+		activate();
 		new ShellMenu("File", "New", "Other...").select();  
 		new DefaultTree();
 		DefaultTreeItem theNewTask = new DefaultTreeItem ("Tasks", "Task");

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/mylyn/tasks/ui/view/TaskRepositoriesView.java
@@ -39,6 +39,7 @@ public class TaskRepositoriesView extends WorkbenchView {
 	 * Saves the task.
 	 */
 	public void saveTask () {
+		activate();
 		new ShellMenu("File", "Save").select(); 
 	}
 	
@@ -49,6 +50,8 @@ public class TaskRepositoriesView extends WorkbenchView {
 	 * @param repoList
 	 */
 	public void createLocalTask (List<TreeItem> repoItems, ArrayList<String> repoList) {
+		
+		activate();
 		
 		int elementIndex = repoList.indexOf("Local");
 		log.info("Found Local Task Repo: " + repoItems.get(elementIndex).getText());	
@@ -73,6 +76,8 @@ public class TaskRepositoriesView extends WorkbenchView {
 	 * @param taskName Task name
 	 */
 	public void activateTask (String taskName) {
+		activate();
+		
 		new ShellMenu("Navigate", "Activate Task...").select(); 
 		new DefaultText().setText(taskName);
 		new PushButton("OK").click();	
@@ -83,7 +88,9 @@ public class TaskRepositoriesView extends WorkbenchView {
 	 * 
 	 * @param taskName Task name
 	 */
-	public void openTask (String taskName) { 
+	public void openTask (String taskName) {
+		activate();
+		
 		new ShellMenu("Navigate", "Open Task...").select();    
 		new DefaultText().setText(taskName);
 		new PushButton("OK").click();	
@@ -93,6 +100,8 @@ public class TaskRepositoriesView extends WorkbenchView {
 	 * Deactivates the task.
 	 */
 	public void deactivateTask () {
+		activate();
+		
 		new ShellMenu("Navigate", "Deactivate Task").select();  
 	}
 	
@@ -100,13 +109,17 @@ public class TaskRepositoriesView extends WorkbenchView {
 	 * Deletes the task.
 	 */
 	public void deleteTask () {
+		activate();
+		
 		new ShellMenu("Edit", "Delete").select();  
 		new PushButton("Yes").click();	
 	}
 	
 	public NewRepositoryWizard newTaskRepositories(){
+		activate();
+		
 		log.info("Creating new repository");
-		open();
+		activate();
 		new ContextMenu("New","Add Task Repository...").select();
 		new DefaultShell("Add Task Repository...");
 		return new NewRepositoryWizard();
@@ -137,7 +150,7 @@ public class TaskRepositoriesView extends WorkbenchView {
 	}
 
 	protected Tree getRepositoriesTree(){
-		open();
+		activate();
 		return new DefaultTree();
 	}
 }

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/rse/ui/view/SystemView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/rse/ui/view/SystemView.java
@@ -38,7 +38,7 @@ public class SystemView extends WorkbenchView {
 	 */
 	public NewConnectionWizardDialog newConnection(){
 		log.info("Creating new connection");
-		this.open();
+		activate();
 		getSystem("Local").select();
 		new ContextMenu("New","Connection...").select();
 		new DefaultShell("New Connection");
@@ -81,7 +81,7 @@ public class SystemView extends WorkbenchView {
 	}
 
 	protected Tree getSystemTree(){
-		open();
+		activate();
 		return new DefaultTree();
 	}
 

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserView.java
@@ -48,6 +48,7 @@ public class BrowserView extends WorkbenchView {
 	 * @param url
 	 */
 	public void openPageURL(String url) {
+		activate();
 		browser.setURL(url);
 		new WaitUntil(new PageIsLoaded(browser), TIMEOUT);
 	}
@@ -56,6 +57,7 @@ public class BrowserView extends WorkbenchView {
 	 * Refreshes currently opened page in browser
 	 */
 	public void refreshPage() {
+		activate();
 		browser.setURL(browser.getURL());
 		new WaitUntil(new PageIsLoaded(browser), TIMEOUT);
 	}
@@ -64,6 +66,7 @@ public class BrowserView extends WorkbenchView {
 	 * Go to the previous page in browser
 	 */
 	public void back() {
+		activate();
 		String prevUrl = browser.getURL();
 		browser.back();
 		new WaitWhile(new BrowserHasURL(this, prevUrl), TIMEOUT);
@@ -74,6 +77,7 @@ public class BrowserView extends WorkbenchView {
 	 * Go to the next page in browser
 	 */
 	public void forward() {
+		activate();
 		String prevUrl = browser.getURL();
 		browser.forward();
 		new WaitWhile(new BrowserHasURL(this, prevUrl), TIMEOUT);
@@ -86,6 +90,7 @@ public class BrowserView extends WorkbenchView {
 	 * @return String URL of the current page
 	 */
 	public String getPageURL() {
+		activate();
 		return browser.getURL();
 	}
 	
@@ -95,6 +100,7 @@ public class BrowserView extends WorkbenchView {
 	 * @return String Text of the current page
 	 */
 	public String getText() {
+		activate();
 		return browser.getText();
 	}
 }

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/console/ConsoleView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/console/ConsoleView.java
@@ -34,6 +34,7 @@ public class ConsoleView extends WorkbenchView {
 	 * @return Console text
 	 */
 	public String getConsoleText() {
+		activate();
 		new WaitUntil(new ConsoleHasTextWidget());
 		// wait for text to appear
 		new WaitWhile(new ConsoleHasText(""),TimePeriod.SHORT,false);
@@ -45,6 +46,7 @@ public class ConsoleView extends WorkbenchView {
 	 */
 	public void clearConsole() {
 		log.info("Clearing console");
+		activate();		
 		new ViewToolItem("Clear Console").click();
 		new WaitUntil(new ConsoleHasText(""));
 		log.info("Console cleared");
@@ -76,6 +78,7 @@ public class ConsoleView extends WorkbenchView {
 	 */
 	public void terminateConsole() {
 		log.info("Terminating console");
+		activate();
 		ViewToolItem terminate = new ViewToolItem("Terminate");
 		if (terminate.isEnabled()) {
 			terminate.click();

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/problems/ProblemsView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/problems/ProblemsView.java
@@ -30,7 +30,7 @@ public class ProblemsView extends WorkbenchView{
 	 * @return
 	 */
 	public List<TreeItem> getAllErrors(){
-		open();
+		activate();
 		new WaitWhile(new MarkerIsUpdating());
 		DefaultTree tree = new DefaultTree();
 		return filter(tree.getItems(), true);
@@ -42,7 +42,7 @@ public class ProblemsView extends WorkbenchView{
 	 * @return
 	 */
 	public List<TreeItem> getAllWarnings(){
-		open();
+		activate();
 		DefaultTree tree = new DefaultTree();
 		return filter(tree.getItems(), false);
 	}
@@ -60,6 +60,7 @@ public class ProblemsView extends WorkbenchView{
 	public List<TreeItem> getErrors(Matcher<String> description,
 			Matcher<String> resource, Matcher<String> path,
 			Matcher<String> location, Matcher<String> type) {
+		activate();
 		return filter(getAllErrors(), description, resource, path,
 				location, type);
 	}
@@ -77,6 +78,7 @@ public class ProblemsView extends WorkbenchView{
 	public List<TreeItem> getWarnings(Matcher<String> description,
 			Matcher<String> resource, Matcher<String> path,
 			Matcher<String> location, Matcher<String> type) {
+		activate();
 		return filter(getAllWarnings(), description, resource, path,
 				location, type);
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/contentoutline/OutlineView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/contentoutline/OutlineView.java
@@ -31,6 +31,7 @@ public class OutlineView extends WorkbenchView {
 	 * @return Collection of outline elements
 	 */
 	public Collection<TreeItem> outlineElements() {
+		activate();
 		return getTreeForView();
 	}
 
@@ -38,6 +39,7 @@ public class OutlineView extends WorkbenchView {
 	 * Clicks on tooltip "Collapse All".
 	 */
 	public void collapseAll() {
+		activate();
 		clickOnToolTip("Collapse All.*");
 	}
 
@@ -45,6 +47,7 @@ public class OutlineView extends WorkbenchView {
 	 * Clicks on tooltip "Sort".
 	 */
 	public void sort() {
+		activate();
 		clickOnToolTip("Sort.*");
 	}
 	
@@ -52,6 +55,7 @@ public class OutlineView extends WorkbenchView {
 	 * Clicks on tooltip "Hide Fields".
 	 */
 	public void hideFields() {
+		activate();
 		clickOnToolTip("Hide Fields.*");
 	}
 
@@ -59,6 +63,7 @@ public class OutlineView extends WorkbenchView {
 	 * Clicks on tooltip "Hide Static Fields and Methods".
 	 */
 	public void hideStaticFieldsAndMethods() {
+		activate();
 		clickOnToolTip("Hide Static Fields and Methods.*");
 	}
 
@@ -66,6 +71,7 @@ public class OutlineView extends WorkbenchView {
 	 * Clicks on tooltip "Hide Non-Public Members".
 	 */
 	public void hideNonPublicMembers() {
+		activate();
 		clickOnToolTip("Hide Non-Public Members.*");
 	}
 
@@ -73,6 +79,7 @@ public class OutlineView extends WorkbenchView {
 	 * Clicks on tooltip "Hide Local Types".
 	 */
 	public void hideLocalTypes() {
+		activate();
 		clickOnToolTip("Hide Local Types.*");
 	}
 
@@ -80,6 +87,7 @@ public class OutlineView extends WorkbenchView {
 	 * Clicks on tooltip "Link with Editor".
 	 */
 	public void linkWithEditor() {
+		activate();
 		clickOnToolTip("Link with Editor.*");
 	}
 	

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogView.java
@@ -50,9 +50,9 @@ public class LogView extends WorkbenchView{
 	 */
 	
 	public List<LogMessage> getOKMessages() {
-		open();
+		activate();
 		setFilter(OK_SEVERITY);
-		open();
+		activate();
 		DefaultTree tree = new DefaultTree();
 		List<TreeItem> treeItems = tree.getAllItems();
 		List<LogMessage> messages = new ArrayList<LogMessage>();
@@ -67,9 +67,9 @@ public class LogView extends WorkbenchView{
 	 * @return list of messages with severity INFO (according to IStatus)
 	 */
 	public List<LogMessage> getInfoMessages() {
-		open();
+		activate();
 		setFilter(INFORMATION_SEVERITY);
-		open();
+		activate();
 		DefaultTree tree = new DefaultTree();
 		List<TreeItem> treeItems = tree.getAllItems();
 		List<LogMessage> messages = new ArrayList<LogMessage>();
@@ -83,9 +83,9 @@ public class LogView extends WorkbenchView{
 	 * @return list of messages with severity WARNING (according to IStatus)
 	 */
 	public List<LogMessage> getWarningMessages() {
-		open();
+		activate();
 		setFilter(WARNING_SEVERITY);
-		open();
+		activate();
 		DefaultTree tree = new DefaultTree();
 		List<TreeItem> treeItems = tree.getAllItems();
 		List<LogMessage> messages = new ArrayList<LogMessage>();
@@ -99,9 +99,9 @@ public class LogView extends WorkbenchView{
 	 * @return list of messages with severity ERROR (according to IStatus)
 	 */
 	public List<LogMessage> getErrorMessages() {
-		open();
+		activate();
 		setFilter(ERROR_SEVERITY);
-		open();
+		activate();
 		DefaultTree tree = new DefaultTree();
 		List<TreeItem> treeItems = tree.getAllItems();
 		List<LogMessage> messages = new ArrayList<LogMessage>();
@@ -115,7 +115,7 @@ public class LogView extends WorkbenchView{
 	 * Clears Error lLog messages
 	 */
 	public void clearLog() {
-		open();
+		activate();
 		new DefaultTree().setFocus();
 		Menu cm = new ContextMenu(CLEAR_LOG);
 		cm.select();	
@@ -125,7 +125,7 @@ public class LogView extends WorkbenchView{
 	 * Deletes Error log messages
 	 */
 	public void deleteLog() {
-		open();
+		activate();
 		new DefaultTree().setFocus();
 		Menu cm = new ContextMenu(DELETE_LOG);
 		cm.select();
@@ -138,7 +138,7 @@ public class LogView extends WorkbenchView{
 	 * Restores Error log messages
 	 */
 	public void restoreLog() {
-		open();
+		activate();
 		new DefaultTree().setFocus();
 		Menu cm = new ContextMenu(RESTORE_LOG);
 		cm.select();			

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/properties/PropertiesView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/properties/PropertiesView.java
@@ -28,7 +28,7 @@ public class PropertiesView extends WorkbenchView{
 	 * @return list of Properties
 	 */
 	public List<PropertiesViewProperty> getProperties(){
-		open();
+		activate();
 		LinkedList<PropertiesViewProperty> properties = new LinkedList<PropertiesViewProperty>();
 		for (TreeItem treeItem : new DefaultTree().getAllItems()){
 			properties.add(new PropertiesViewProperty(treeItem));
@@ -43,7 +43,7 @@ public class PropertiesView extends WorkbenchView{
 	 * @return ViewProperty with propertyName
 	 */
 	public PropertiesViewProperty getProperty(String... propertyNamePath){
-		open();
+		activate();
 		return new PropertiesViewProperty(new DefaultTreeItem(propertyNamePath));
 	}
 	
@@ -53,7 +53,7 @@ public class PropertiesView extends WorkbenchView{
 	 * @param toggle Indicates whether to show categories
 	 */
 	public void toggleShowCategories(boolean toggle){
-		open();
+		activate();
 		new ViewToolItem("Show Categories")
 			.toggle(toggle);
 	}
@@ -65,7 +65,7 @@ public class PropertiesView extends WorkbenchView{
 	 * @param toggle Indicates whether to show advanced properties
 	 */
 	public void toggleShowAdvancedProperties(boolean toggle){
-		open();
+		activate();
 		new ViewToolItem("Show Advanced Properties")
 			.toggle(toggle);
 	}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/ServersView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/wst/server/ui/view/ServersView.java
@@ -41,7 +41,7 @@ public class ServersView extends WorkbenchView {
 	 */
 	public NewServerWizardDialog newServer(){
 		log.info("Creating new server");
-		open();
+		activate();
 		new ContextMenu("New","Server").select();
 		new DefaultShell("New Server");
 		return new NewServerWizardDialog();
@@ -85,7 +85,7 @@ public class ServersView extends WorkbenchView {
 	}
 
 	protected Tree getServersTree(){
-		open();
+		activate();
 		return new DefaultTree();
 	}
 

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/server/ServerReqBase.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/server/ServerReqBase.java
@@ -62,6 +62,7 @@ public abstract class ServerReqBase {
 	private org.jboss.reddeer.eclipse.wst.server.ui.view.Server getConfiguredServer(ConfiguredServerInfo lastServerConfig)
 			throws ConfiguredServerNotFoundException {
 		ServersView serversView = new ServersView();
+		serversView.open();
 		final String serverName = lastServerConfig.getServerName();
 		try {
 			return serversView.getServer(serverName);

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/datatools/ui/ConnectionProfileTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/datatools/ui/ConnectionProfileTest.java
@@ -29,7 +29,9 @@ public class ConnectionProfileTest {
 		connWizard.open();
 		connWizard.createFlatFileProfile(flatProfile);
 
-		List<String> flatFileSources = new DataSourceExplorer().getFlatFileDataSources();
+		DataSourceExplorer dataSourceExplorer = new DataSourceExplorer();
+		dataSourceExplorer.open();
+		List<String> flatFileSources = dataSourceExplorer.getFlatFileDataSources();
 		assertTrue("Profile '" + profile + "' isn't available", flatFileSources.contains(profile));
 	}
 

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/datatools/ui/GenericConnectionProfileTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/datatools/ui/GenericConnectionProfileTest.java
@@ -71,7 +71,9 @@ public class GenericConnectionProfileTest {
 		w.open();
 		w.createDatabaseProfile(dbProfile);
 
-		List<String> dbSources = new DataSourceExplorer().getDatabaseConnections();
+		DataSourceExplorer dataSourceExplorer = new DataSourceExplorer();
+		dataSourceExplorer.open();
+		List<String> dbSources = dataSourceExplorer.getDatabaseConnections();
 		assertTrue("Profile '" + profile + "' isn't available", dbSources.contains(profile));
 	}
 }

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/rse/ui/view/SystemTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/rse/ui/view/SystemTest.java
@@ -26,6 +26,7 @@ public class SystemTest extends SystemViewTestCase {
 	public void setUp() {
 		createSystem("127.0.0.1", SYSTEM_1, SystemType.SSH_ONLY);
 		createSystem("localhost", SYSTEM_2, SystemType.SSH_ONLY);
+		remoteSystemView.open();
 		system1 = remoteSystemView.getSystem(SYSTEM_1);
 	}
 

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/rse/ui/view/SystemViewTestCase.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/rse/ui/view/SystemViewTestCase.java
@@ -29,6 +29,7 @@ public class SystemViewTestCase {
 	
 	protected void createSystem(String hostname, String connectionName, SystemType type){
 		
+		remoteSystemView.open();
 		wizardDialog = remoteSystemView.newConnection();
 		
 		NewConnectionWizardSelectionPage selectionPage = new NewConnectionWizardSelectionPage();

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/properties/PropertiesViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/properties/PropertiesViewTest.java
@@ -41,6 +41,7 @@ public class PropertiesViewTest {
 	@Test
 	public void getProperty(){
 		PropertiesView propertiesView = new PropertiesView();
+		propertiesView.open();
 		propertiesView.toggleShowCategories(true);
 		String namePropertyValue = propertiesView.getProperty("Info","name")
 			.getPropertyValue();
@@ -52,6 +53,7 @@ public class PropertiesViewTest {
 	@Test
 	public void getProperties(){
 		PropertiesView propertiesView = new PropertiesView();
+		propertiesView.open();
 		propertiesView.toggleShowCategories(true);
 		List<PropertiesViewProperty> properties = propertiesView.getProperties();
 		assertTrue("Expected cound of properties was 8 but is" + properties.size() ,
@@ -75,6 +77,7 @@ public class PropertiesViewTest {
 	@Test
 	public void toggleShowCategories(){
 		PropertiesView propertiesView = new PropertiesView();
+		propertiesView.open();
 		propertiesView.toggleShowCategories(true);
 		final String infoPropName="Info";
 		// Properties View has to contain Info property
@@ -88,6 +91,7 @@ public class PropertiesViewTest {
 	@After
 	public void tearDown() {
 		PackageExplorer packageExplorer = new PackageExplorer();
+		packageExplorer.open();
 		if (packageExplorer.containsProject(PropertiesViewTest.TEST_PROJECT_NAME)) {
 			DeleteUtils.forceProjectDeletion(packageExplorer.getProject(PropertiesViewTest.TEST_PROJECT_NAME),
 				true);

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ModifyModulesDialogTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ModifyModulesDialogTest.java
@@ -44,7 +44,7 @@ public class ModifyModulesDialogTest extends ServersViewTestCase{
 	@Before
 	public void setUp(){
 		createServer(SERVER);
-
+		serversView.open();
 		server = serversView.getServer(SERVER);
 	}
 

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ServersViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ServersViewTest.java
@@ -17,6 +17,7 @@ public class ServersViewTest extends ServersViewTestCase{
 
 	@Test
 	public void newServer(){
+		serversView.open();
 		wizardDialog = serversView.newServer();
 
 		Shell shell = new DefaultShell();
@@ -25,6 +26,7 @@ public class ServersViewTest extends ServersViewTestCase{
 
 	@Test
 	public void getServers_noServers(){
+		serversView.open();
 		List<Server> servers = serversView.getServers();
 		
 		assertThat(servers.size(), is(0));
@@ -35,6 +37,7 @@ public class ServersViewTest extends ServersViewTestCase{
 		createServer("Server AB");
 		createServer("Server A");
 
+		serversView.open();
 		List<Server> servers = serversView.getServers();
 		assertThat(servers.size(), is(2));
 		assertThat(servers.get(0).getLabel().getName(), is("Server A"));
@@ -43,11 +46,13 @@ public class ServersViewTest extends ServersViewTestCase{
 
 	@Test(expected=EclipseLayerException.class)
 	public void getServer_noServers(){
+		serversView.open();
 		serversView.getServer("Server A");
 	}
 
 	@Test(expected=EclipseLayerException.class)
 	public void getServer_notFound(){
+		serversView.open();
 		createServer("Server AB");
 
 		serversView.getServer("Server A");
@@ -55,6 +60,7 @@ public class ServersViewTest extends ServersViewTestCase{
 
 	@Test
 	public void getServer(){
+		serversView.open();
 		createServer("Server AB");
 		createServer("Server A");
 

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ServersViewTestCase.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ServersViewTestCase.java
@@ -43,6 +43,7 @@ public class ServersViewTestCase {
 	}
 	
 	protected void createServer(String name) {
+		serversView.open();
 		wizardDialog = serversView.newServer();
 
 		NewServerWizardPage newServerPage = wizardDialog.getFirstPage();

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/wizard/NewServerWizardPageTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/wizard/NewServerWizardPageTest.java
@@ -33,6 +33,7 @@ public class NewServerWizardPageTest {
 	@Before
 	public void setUp(){
 		view = new ServersView();
+		view.open();
 		wizard = view.newServer();
 		wizardPage = wizard.getFirstPage();
 	}

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/wst/common/project/facet/ui/RuntimesPropertyPageTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/wst/common/project/facet/ui/RuntimesPropertyPageTest.java
@@ -40,7 +40,9 @@ public class RuntimesPropertyPageTest {
 
 		wizard.finish();
 		
-		propertyPage = new RuntimesPropertyPage(new PackageExplorer().getProject(PROJECT));
+		PackageExplorer packageExplorer = new PackageExplorer();
+		packageExplorer.open();
+		propertyPage = new RuntimesPropertyPage(packageExplorer.getProject(PROJECT));
 	}
 	
 	@Before

--- a/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/cleanworkspace/CleanWorkspaceRequirementTest.java
+++ b/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/cleanworkspace/CleanWorkspaceRequirementTest.java
@@ -66,8 +66,10 @@ public class CleanWorkspaceRequirementTest {
 		projectWizard.open();
 		projectWizard.getFirstPage().setProjectName("TestProject");
 		projectWizard.finish();
+		PackageExplorer packageExplorer = new PackageExplorer();
+		packageExplorer.open();
 		assertFalse("Project should be imported, but isn't",
-				new PackageExplorer().getProjects().isEmpty());
+				packageExplorer.getProjects().isEmpty());
 	}
 	
 	@CleanWorkspace

--- a/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/server/ServerPresentTest.java
+++ b/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/server/ServerPresentTest.java
@@ -25,6 +25,7 @@ public class ServerPresentTest {
 	public void isServerPresentTest(){
 		
 		ServersView sw = new ServersView();
+		sw.open();
 		Server s = sw.getServer(requirement.getServerNameLabelText(requirement.getConfig()));
 		assertTrue(s != null);
 	}

--- a/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/server/ServerRunningTest.java
+++ b/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/server/ServerRunningTest.java
@@ -26,6 +26,7 @@ public class ServerRunningTest {
 	public void isServerRunningTest(){
 		
 		ServersView sw = new ServersView();
+		sw.open();
 		Server s = sw.getServer(requirement.getServerNameLabelText(requirement.getConfig()));
 		assertTrue(s.getLabel().getState().equals(ServerState.STARTED));
 	}

--- a/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/server/ServerStoppedTest.java
+++ b/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/server/ServerStoppedTest.java
@@ -26,6 +26,7 @@ public class ServerStoppedTest {
 	public void isServerStoppedTest(){
 		
 		ServersView sw = new ServersView();
+		sw.open();
 		Server s = sw.getServer(requirement.getServerNameLabelText(requirement.getConfig()));
 		assertTrue(s.getLabel().getState().equals(ServerState.STOPPED));
 	}

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/EditorTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/EditorTest.java
@@ -56,7 +56,9 @@ public class EditorTest {
 
 	@Before
 	public void setup() {
-		new PackageExplorer().getProject("testProject")
+		PackageExplorer packageExplorer = new PackageExplorer();
+		packageExplorer.open();
+		packageExplorer.getProject("testProject")
 				.getProjectItem("editorTest.min").open();
 	}
 
@@ -72,7 +74,9 @@ public class EditorTest {
 	
 	@AfterClass
 	public static void teardownClass(){
-		List<Project> projects = new ProjectExplorer().getProjects();
+		ProjectExplorer projectExplorer = new ProjectExplorer();
+		projectExplorer.open();
+		List<Project> projects = projectExplorer.getProjects();
 		for (Project p: projects){
 			DeleteUtils.forceProjectDeletion(p,true);
 		}
@@ -165,7 +169,9 @@ public class EditorTest {
 	public void getEditorByTitleTest() {
 		DefaultEditor editor = new DefaultEditor("editorTest.min");
 		assertNotNull(editor);
-		new PackageExplorer().getProject("testProject")
+		PackageExplorer packageExplorer = new PackageExplorer();
+		packageExplorer.open();
+		packageExplorer.getProject("testProject")
 				.getProjectItem("editorTest1.min").open();
 		editor = new DefaultEditor("editorTest.min");
 		assertNotNull(editor);
@@ -180,7 +186,9 @@ public class EditorTest {
 
 	@Test
 	public void switchEditorTest() {
-		new PackageExplorer().getProject("testProject")
+		PackageExplorer packageExplorer = new PackageExplorer();
+		packageExplorer.open();
+		packageExplorer.getProject("testProject")
 				.getProjectItem("editorTest1.min").open();
 		assertTrue(new DefaultEditor().isActive());
 		assertTrue(new DefaultEditor("editorTest.min").isActive()); // should
@@ -191,7 +199,9 @@ public class EditorTest {
 	@Test(expected = WorkbenchPartNotFound.class)
 	public void closeNotActiveEditorTest() {
 		Editor editor = new DefaultEditor();
-		new PackageExplorer().getProject("testProject")
+		PackageExplorer packageExplorer = new PackageExplorer();
+		packageExplorer.open();
+		packageExplorer.getProject("testProject")
 				.getProjectItem("editorTest1.min").open();
 		editor.close(false);
 		new DefaultEditor("editorTest.min"); // should be closed now


### PR DESCRIPTION
Currently many if not most of different view implementation methods calls open which is comfortable for user but ignores unexpected view closing and similar scenarios.

Goal is to find appropriate balance between detailed test control and user comfort

Suggestion1:  Open is required, activate() is called by default
Pros: User knows when he don't have opened view
Cons: User must open view explicitly, user don't know if view was activated or not (isActive() can be implemented)

Suggestion2: Nothing is required, view methods are able to perform any method without any prerequisites  (most views are implemented this way today)
Pros: User can call any method directly
Cost: User don't know if view was opened/acitavted (solution is to to implement isOpen() & isActive() method)

Suggestion3: Nothing is expected, view must be opened or activated (if it's open)
Pros: User has complete control over the state
Cost: Not comfortable, client must all open and activate all the time

UPDATE1: Suggestion 4 added
Suggestion 4 (slightly modified suggestion 1): open() is called in constructor but (re)opening is not assured by methods, just an activation 

We should have an agreement and follow one of these approaches through all view and rest of RedDeer API. RedDeer was meant to take care of this burden from client:

Mostly client doesn't care about state (open/closed,activate/non-activate) of view and want to call particular action like:

``` java
ProblemsView v = new ProblemsView();
list = ProblemsView.getAllErrrors();

Outline view v2 = new OutlineView();
v2.hideFields();
elements = v2.outlineElements();
```

For such special cases when user want's to know the state he could use methods like isActivate(), isOpen();

This discussion is open and we should have common consensus in this before RedDeer 1.0 . Note that RedDeer goal was to simplify and avoid unnecessary calls/prerequisites for general cases. Please share you ideas/votes/comments:
