### PR TITLE
Add ToolItem to WidgetResolver

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/WidgetResolver.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/WidgetResolver.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swt.widgets.Widget;
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
@@ -164,8 +165,9 @@ public class WidgetResolver  {
 		else if (w instanceof ToolBar) {
 			Widget[] items = ((ToolBar) w).getItems();
 			children = Arrays.asList(items);
-		} 
-		else if (w instanceof Table) {
+		} else if (w instanceof ToolItem) {
+			// do nothing
+		} else if (w instanceof Table) {
 			Widget[] items = ((Table) w).getItems();
 			children = Arrays.asList(items);
 		}


### PR DESCRIPTION
There is a bunch of annoying warning messages that could be resolved by adding ToolItem to the supported types in WidgetResolver (with empty implementation)
