### PR TITLE
Red Deer is not able to locate a ComboBox within a group

### DIFF
--- a/plugins/org.jboss.reddeer.recorder/src/main/java/org/jboss/reddeer/swt/generator/framework/rules/simple/ComboRule.java
+++ b/plugins/org.jboss.reddeer.recorder/src/main/java/org/jboss/reddeer/swt/generator/framework/rules/simple/ComboRule.java
@@ -43,11 +43,13 @@ public class ComboRule extends AbstractSimpleRedDeerRule{
 	public List<String> getActions() {
 		StringBuilder builder = new StringBuilder();
 		List<String> toReturn = new ArrayList<String>();
-		builder.append("new DefaultCombo(");
-		builder.append(RedDeerUtils.getReferencedCompositeString(composites));
 		if(label != null){
+			builder.append("new LabeledCombo(");
+			builder.append(RedDeerUtils.getReferencedCompositeString(composites));
 			builder.append("\""+label+"\"");
 		} else {
+			builder.append("new DefaultCombo(");
+			builder.append(RedDeerUtils.getReferencedCompositeString(composites));
 			builder.append(index);
 		}
 		builder.append(")");
@@ -65,7 +67,11 @@ public class ComboRule extends AbstractSimpleRedDeerRule{
 	@Override
 	public List<String> getImports() {
 		List<String> toReturn = new ArrayList<String>();
-		toReturn.add("org.jboss.reddeer.swt.impl.combo.DefaultCombo");
+		if(label != null){
+			toReturn.add("org.jboss.reddeer.swt.impl.combo.LabeledCombo");
+		} else {
+			toReturn.add("org.jboss.reddeer.swt.impl.combo.DefaultCombo");
+		}
 		for(ReferencedComposite r: composites){
 			toReturn.add(r.getImport());
 		}


### PR DESCRIPTION
The context is creating a new maven project. The recorder is able to correctly record the following statements:

new ShellMenu("File","New","Other...").select();
new DefaultTreeItem("Maven","Maven Project").select();
new PushButton("Next >").click();
new CheckBox("Create a simple project (skip archetype selection)").toggle(true);
new PushButton("Next >").click();
new DefaultCombo(new DefaultGroup("Artifact"),"Group Id:").setText("Test100");
new DefaultCombo(new DefaultGroup("Artifact"),"Artifact Id:").setText("test100");
new PushButton("Finish").click();

But - these statements fail when the test is run - 'no matching widget':

new DefaultCombo(new DefaultGroup("Artifact"),"Group Id:").setText("Test100");
new DefaultCombo(new DefaultGroup("Artifact"),"Artifact Id:").setText("test100");
