### PR TITLE
Runtime isnt removed, because its being searched by server name, not runtime name

### DIFF
--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/server/ServerReqBase.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/server/ServerReqBase.java
@@ -89,7 +89,8 @@ public abstract class ServerReqBase {
 		preferenceDialog.open();
 		RuntimePreferencePage runtimePage = new RuntimePreferencePage();
 		preferenceDialog.select(runtimePage);
-		runtimePage.removeRuntime(new Runtime(lastServerConfig.getServerName(), "test"));
+		String runtimeName = getRuntimeNameLabelText(lastServerConfig.getConfig());
+		runtimePage.removeRuntime(new Runtime(runtimeName, "test"));
 		preferenceDialog.ok();
 	}
 	


### PR DESCRIPTION
#861 has a bug.

runtimePage.removeRuntime(new Runtime(lastServerConfig.getServerName(), "test")); is wrong. No runtime is ever found because you are using server name, not runtime name.
