### PR TITLE
Enhance QuickFixWizard finish method

### DIFF
--- a/plugins/org.eclipse.reddeer.eclipse/src/org/eclipse/reddeer/eclipse/ui/views/markers/QuickFixWizard.java
+++ b/plugins/org.eclipse.reddeer.eclipse/src/org/eclipse/reddeer/eclipse/ui/views/markers/QuickFixWizard.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.reddeer.eclipse.ui.views.markers;
 
+import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
+import org.eclipse.reddeer.swt.condition.ShellHasChildrenOrIsNotAvailable;
 import org.eclipse.reddeer.swt.condition.ShellIsAvailable;
 import org.eclipse.reddeer.swt.impl.button.PushButton;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
@@ -45,7 +47,7 @@ public class QuickFixWizard extends DefaultShell {
 	 */
 	public void finish() {
 		new PushButton("Finish").click();
-		new WaitWhile(new ShellIsAvailable(this));
+		new WaitUntil(new ShellHasChildrenOrIsNotAvailable(this));
 	}
 	
 }

--- a/plugins/org.eclipse.reddeer.swt/src/org/eclipse/reddeer/swt/condition/ShellHasChildrenOrIsNotAvailable.java
+++ b/plugins/org.eclipse.reddeer.swt/src/org/eclipse/reddeer/swt/condition/ShellHasChildrenOrIsNotAvailable.java
@@ -34,10 +34,10 @@ public class ShellHasChildrenOrIsNotAvailable extends AbstractWaitCondition {
 
 	/**
 	 * Default constructor.
-	 * @param deleteShell instance of shell to test
+	 * @param shell instance of shell to test
 	 */
-	public ShellHasChildrenOrIsNotAvailable(Shell deleteShell) {
-		this.shell = deleteShell;
+	public ShellHasChildrenOrIsNotAvailable(Shell shell) {
+		this.shell = shell;
 		this.resultChildren = new ArrayList<>();
 	}
 


### PR DESCRIPTION
https://github.com/jboss-reddeer/reddeer/blob/9d8399ac7db6e1180cc93798bcabcdd3011073a3/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/markers/QuickFixWizard.java#L48 sometimes clicking finish may invoke another dialog so the condition on line 48 fails with timeout. We could add another argument tu finish method finish(String shellNameToBeOpened) or change the shellisavailable to shellhaschildrenorisdisposed