### PR TITLE
A requirement matcher cannot access parent attributes

### DIFF
--- a/plugins/org.eclipse.reddeer.junit/src/org/eclipse/reddeer/junit/requirement/configuration/RequirementConfiguration.java
+++ b/plugins/org.eclipse.reddeer.junit/src/org/eclipse/reddeer/junit/requirement/configuration/RequirementConfiguration.java
@@ -10,7 +10,8 @@
  *******************************************************************************/
 package org.eclipse.reddeer.junit.requirement.configuration;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import org.eclipse.reddeer.junit.requirement.RequirementException;
 
@@ -64,20 +65,24 @@ public interface RequirementConfiguration {
 	}
 
 	/**
-	 * Gets an object from configuration with given attribute name.
+	 * Gets an object from configuration with given attribute name by invocation the
+	 * appropriate "get" method.
 	 * 
 	 * @param attributeName
 	 *            attribute name
 	 * @return attribute object
 	 */
 	default Object getAttributeValue(String attributeName) {
+		String methodName = "get" + attributeName.substring(0, 1).toUpperCase() + attributeName.substring(1);
 		try {
-			Field attribute = this.getClass().getDeclaredField(attributeName);
-			attribute.setAccessible(true);
-			return attribute.get(this);
-		} catch (NoSuchFieldException nsfe) {
-			throw new RequirementException("Attribute " + attributeName + " does not exists in configuration class "
-					+ this.getClass().getName(), nsfe);
+			Method method = this.getClass().getMethod(methodName);
+			return method.invoke(this);
+		} catch (NoSuchMethodException nsfe) {
+			throw new RequirementException(
+					"Cannot find method " + methodName + " in configuration class " + this.getClass().getName(), nsfe);
+		} catch (InvocationTargetException ite) {
+			throw new RequirementException(
+					"Cannot invoke method " + methodName + " in configuration class " + this.getClass().getName(), ite);
 		} catch (IllegalArgumentException e) {
 			throw new RequirementException("Something went wrong when it should not get wrong.", e);
 		} catch (IllegalAccessException e) {

--- a/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/requirement/configuration/resources/SubConfiguration.java
+++ b/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/requirement/configuration/resources/SubConfiguration.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.reddeer.junit.test.requirement.configuration.resources;
+
+/**
+ * 
+ * @author Andrej Podhradsky (apodhrad@redhat.com)
+ *
+ */
+public class SubConfiguration extends SimpleConfiguration {
+
+	private String subName;
+
+	public String getSubName() {
+		return subName;
+	}
+
+	public void setSubName(String subName) {
+		this.subName = subName;
+	}
+
+}

--- a/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/requirement/configuration/resources/SubRequirement.java
+++ b/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/requirement/configuration/resources/SubRequirement.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.reddeer.junit.test.requirement.configuration.resources;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.eclipse.reddeer.junit.requirement.ConfigurableRequirement;
+import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SubRequirement.SubReq;
+
+/**
+ * 
+ * @author Andrej Podhradsky (apodhrad@redhat.com)
+ *
+ */
+public class SubRequirement implements ConfigurableRequirement<SubConfiguration, SubReq> {
+
+	private SubReq declaration;
+	private SubConfiguration config;
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	public @interface SubReq {
+
+	}
+
+	@Override
+	public void fulfill() {
+
+	}
+
+	@Override
+	public void setDeclaration(SubReq declaration) {
+		this.declaration = declaration;
+	}
+
+	@Override
+	public SubReq getDeclaration() {
+		return declaration;
+	}
+
+	@Override
+	public void cleanUp() {
+	}
+
+	@Override
+	public Class<SubConfiguration> getConfigurationClass() {
+		return SubConfiguration.class;
+	}
+
+	@Override
+	public void setConfiguration(SubConfiguration configuration) {
+		config = configuration;
+	}
+
+	@Override
+	public SubConfiguration getConfiguration() {
+		return config;
+	}
+
+}

--- a/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/requirement/matcher/RequirementMatcherTest.java
+++ b/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/requirement/matcher/RequirementMatcherTest.java
@@ -13,16 +13,19 @@ package org.eclipse.reddeer.junit.test.requirement.matcher;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SimpleConfiguration;
-import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SimpleRequirement;
-import org.eclipse.reddeer.junit.test.requirement.configuration.resources.ComplexConfiguration;
-import org.eclipse.reddeer.junit.test.requirement.configuration.resources.ComplexRequirement;
 import org.eclipse.reddeer.common.matcher.RegexMatcher;
 import org.eclipse.reddeer.common.matcher.VersionMatcher;
 import org.eclipse.reddeer.junit.requirement.RequirementException;
 import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.junit.test.requirement.configuration.resources.ComplexConfiguration;
+import org.eclipse.reddeer.junit.test.requirement.configuration.resources.ComplexRequirement;
 import org.eclipse.reddeer.junit.test.requirement.configuration.resources.ComplexRequirement.ComplexReq;
+import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SimpleConfiguration;
+import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SimpleRequirement;
 import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SimpleRequirement.SimpleReq;
+import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SubConfiguration;
+import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SubRequirement;
+import org.eclipse.reddeer.junit.test.requirement.configuration.resources.SubRequirement.SubReq;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -33,6 +36,9 @@ public class RequirementMatcherTest {
 	
 	private static ComplexRequirement complexReq;
 	private static ComplexConfiguration complexConfig;
+	
+	private static SubRequirement subReq;
+	private static SubConfiguration subConfig;
 
 	@BeforeClass
 	public static void setup() {
@@ -50,12 +56,26 @@ public class RequirementMatcherTest {
 		complexConfig.setComplexVersion("2.0");
 		complexConfig.setSimpleConfiguration(simpleConfig);
 		complexReq.setConfiguration(complexConfig);
+		
+		subReq = new SubRequirement();
+		subConfig = new SubConfiguration();
+		subConfig.setName("SimpleConfig");
+		subConfig.setSubName("SubConfig");
+		subReq.setConfiguration(subConfig);
 	}
 
 	@Test
 	public void testNestedAttributeOnPreciseMatch() {
 		RequirementMatcher matcher = new RequirementMatcher(ComplexReq.class, "simpleConfiguration.name", "SimpleConfig");
 		assertTrue("Name attribute of configuration should be matched on precise match", matcher.matches(complexConfig));
+	}
+	
+	@Test
+	public void testNestedAttributeOnPreciseMatchInSubClass() {
+		RequirementMatcher matcher = new RequirementMatcher(SubReq.class, "name", "SimpleConfig");
+		assertTrue("Name attribute of configuration should be matched on precise match", matcher.matches(subConfig));
+		matcher = new RequirementMatcher(SubReq.class, "subName", "SubConfig");
+		assertTrue("Name attribute of configuration should be matched on precise match", matcher.matches(subConfig));
 	}
 	
 	@Test
@@ -159,4 +179,5 @@ public class RequirementMatcherTest {
 		RequirementMatcher matcher = new RequirementMatcher(SimpleReq.class, "version", new VersionMatcher("[0.9.0;1.1.1)"));
 		assertTrue("Version attribute should match to version matcher with value [0.9.0;1.1.1)", matcher.matches(simpleConfig));
 	}
+
 }


### PR DESCRIPTION
Assume
```
class A {
    private String name;
}

class B extends A {
    private String surname;
}
```
The logic in requirement matchers cannot access "b.name".