### PR TITLE
Remove the need to implement RequirementConfiguration in all classes

### DIFF
--- a/plugins/org.eclipse.reddeer.junit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.reddeer.junit/META-INF/MANIFEST.MF
@@ -39,4 +39,5 @@ Export-Package: org.eclipse.reddeer.junit,
  org.eclipse.reddeer.junit.requirement.matcher,
  org.eclipse.reddeer.junit.runner,
  org.eclipse.reddeer.junit.screenshot,
+ org.eclipse.reddeer.junit.util,
  org.eclipse.reddeer.junit.watcher

--- a/plugins/org.eclipse.reddeer.junit/src/org/eclipse/reddeer/junit/requirement/configuration/RequirementConfiguration.java
+++ b/plugins/org.eclipse.reddeer.junit/src/org/eclipse/reddeer/junit/requirement/configuration/RequirementConfiguration.java
@@ -10,11 +10,6 @@
  *******************************************************************************/
 package org.eclipse.reddeer.junit.requirement.configuration;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
-import org.eclipse.reddeer.junit.requirement.RequirementException;
-
 /**
  * Requirement configuration represents a data holder, container for data
  * required to executed more advanced logic with requirements. Requirement
@@ -33,80 +28,4 @@ public interface RequirementConfiguration {
 	 */
 	String getId();
 
-	/**
-	 * Gets text value of a configuration attribute by its name.
-	 * 
-	 * @param attributeName
-	 *            name of configuration attribute.
-	 * @return attribute value
-	 */
-	default String getAttribute(String attributeName) {
-		return (String) getAttributeValue(attributeName);
-	}
-
-	/**
-	 * Gets object value of a configuration attribute by its name and class of
-	 * attribute.
-	 * 
-	 * @param clazz
-	 *            class of an attribute
-	 * @param attributeName
-	 *            attribute name to get its value
-	 * @return attribute object
-	 */
-	default <T extends Object> T getAttribute(Class<T> attributeClass, String attributeName) {
-		Object attribute = getAttributeValue(attributeName);
-		if (attributeClass.isAssignableFrom(attribute.getClass())) {
-			return attributeClass.cast(attribute);
-		} else {
-			throw new RequirementException("Attribute class of attribute " + attributeName
-					+ " does not match required attribute class" + attributeClass);
-		}
-	}
-
-	/**
-	 * Gets an object from configuration with given attribute name by invocation the
-	 * appropriate "get" method.
-	 * 
-	 * @param attributeName
-	 *            attribute name
-	 * @return attribute object
-	 */
-	default Object getAttributeValue(String attributeName) {
-		String methodName = "get" + attributeName.substring(0, 1).toUpperCase() + attributeName.substring(1);
-		try {
-			Method method = this.getClass().getMethod(methodName);
-			return method.invoke(this);
-		} catch (NoSuchMethodException nsfe) {
-			throw new RequirementException(
-					"Cannot find method " + methodName + " in configuration class " + this.getClass().getName(), nsfe);
-		} catch (InvocationTargetException ite) {
-			throw new RequirementException(
-					"Cannot invoke method " + methodName + " in configuration class " + this.getClass().getName(), ite);
-		} catch (IllegalArgumentException e) {
-			throw new RequirementException("Something went wrong when it should not get wrong.", e);
-		} catch (IllegalAccessException e) {
-			throw new RequirementException("Cannot access attribute " + attributeName + " in configuration instance "
-					+ this.getClass().getName(), e);
-		}
-	}
-
-	/**
-	 * Gets nested attribute. Pattern for nested attribute is with dot notation.
-	 * All attributes between the top level configuration and the desired
-	 * attribute must implement this interface as well.
-	 * 
-	 * @param attributePattern
-	 *            attribute pattern, e.g.
-	 *            "nestedConfig.anotherNestedConfig.attributeName"
-	 * @return string value of attribute
-	 */
-	default String getNestedAttribute(String attributePattern) {
-		RequirementConfiguration requirementConfig = this;
-		String[] attributePath = attributePattern.split("\\.");
-		for (int i = 0; i < attributePath.length - 1; i++) {
-			requirementConfig = requirementConfig.getAttribute(RequirementConfiguration.class, attributePath[i]);
-		}
-		return requirementConfig.getAttribute(attributePath[attributePath.length - 1]);
-	}
 }

--- a/plugins/org.eclipse.reddeer.junit/src/org/eclipse/reddeer/junit/requirement/matcher/RequirementMatcher.java
+++ b/plugins/org.eclipse.reddeer.junit/src/org/eclipse/reddeer/junit/requirement/matcher/RequirementMatcher.java
@@ -13,6 +13,7 @@ package org.eclipse.reddeer.junit.requirement.matcher;
 import java.lang.annotation.Annotation;
 
 import org.eclipse.reddeer.junit.requirement.configuration.RequirementConfiguration;
+import org.eclipse.reddeer.junit.util.ReflectionUtil;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -43,9 +44,7 @@ public class RequirementMatcher extends TypeSafeMatcher<RequirementConfiguration
 	}
 	
 	public RequirementMatcher(Class<? extends Annotation> clazz, String attributeName, String attributeValue) {
-		this.attributeValueMatcher = new IsEqual<String>(attributeValue);
-		this.attributeName = attributeName;
-		configurationClass = clazz;
+		this(clazz, attributeName, new IsEqual<String>(attributeValue));
 	}
 
 	/**
@@ -72,7 +71,7 @@ public class RequirementMatcher extends TypeSafeMatcher<RequirementConfiguration
 
 	@Override
 	protected boolean matchesSafely(RequirementConfiguration item) {
-		String value = item.getNestedAttribute(attributeName);
+		Object value = ReflectionUtil.getValue(item, attributeName);
 		return attributeValueMatcher.matches(value);
 	}	
 }

--- a/plugins/org.eclipse.reddeer.junit/src/org/eclipse/reddeer/junit/util/ReflectionUtil.java
+++ b/plugins/org.eclipse.reddeer.junit/src/org/eclipse/reddeer/junit/util/ReflectionUtil.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.reddeer.junit.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.reddeer.junit.requirement.RequirementException;
+
+/**
+ * Util class which provides methods for a better manipulation with Java
+ * reflection.
+ * 
+ * @author Andrej Podhradsky (apodhrad@redhat.com)
+ *
+ */
+public class ReflectionUtil {
+
+	/**
+	 * Gets a value specified by property access syntax, e.g. "person.name".
+	 * 
+	 * @param propertySyntax
+	 *            property syntax
+	 * @return value of the given property syntax
+	 */
+	public static Object getValue(Object obj, String propertySyntax) {
+		if (obj == null) {
+			throw new IllegalArgumentException("Object cannot be null");
+		}
+		if (propertySyntax == null || propertySyntax.length() == 0) {
+			throw new IllegalArgumentException("Property syntax cannot be null or empty");
+		}
+		Object result = obj;
+		String[] properties = propertySyntax.split("\\.");
+		List<String> propertyPath = new ArrayList<>();
+		for (String property : properties) {
+			if (result == null) {
+				throw new RequirementException("Cannot access " + propertySyntax + " since "
+						+ String.join(".", propertyPath) + " was resolved as null");
+			}
+			String methodName = "get" + property.substring(0, 1).toUpperCase() + property.substring(1);
+			try {
+				Method method = result.getClass().getMethod(methodName);
+				result = method.invoke(result);
+			} catch (NoSuchMethodException | InvocationTargetException | IllegalArgumentException
+					| IllegalAccessException e) {
+				throw new RequirementException(
+						"Cannot access " + property + " in " + result.getClass().getCanonicalName(), e);
+			}
+			propertyPath.add(property);
+		}
+		return result;
+	}
+
+}

--- a/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/requirement/configuration/RequirementConfigurationTest.java
+++ b/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/requirement/configuration/RequirementConfigurationTest.java
@@ -10,7 +10,8 @@
  *******************************************************************************/
 package org.eclipse.reddeer.junit.test.requirement.configuration;
 
-import static org.junit.Assert.*;
+import static org.eclipse.reddeer.junit.util.ReflectionUtil.getValue;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.reddeer.junit.requirement.RequirementException;
 import org.eclipse.reddeer.junit.test.requirement.configuration.resources.ComplexConfiguration;
@@ -23,7 +24,7 @@ public class RequirementConfigurationTest {
 	private SimpleConfiguration simpleConfig;
 	private ComplexConfiguration complexConfig;
 	private SimpleConfiguration simpleConfig2;
-	
+
 	private String version1 = "version1";
 	private String name1 = "name1";
 	private String type1 = "type1";
@@ -33,68 +34,59 @@ public class RequirementConfigurationTest {
 	private String cname = "cname";
 	private String ctype = "ctype";
 	private String cversion = "cversion";
-	
+
 	@Before
 	public void setup() {
 		simpleConfig = new SimpleConfiguration();
 		simpleConfig.setName(name1);
 		simpleConfig.setType(type1);
 		simpleConfig.setVersion(version1);
-		
+
 		simpleConfig2 = new SimpleConfiguration();
 		simpleConfig2.setName(name2);
 		simpleConfig2.setType(type2);
 		simpleConfig2.setVersion(version2);
-		
+
 		complexConfig = new ComplexConfiguration();
 		complexConfig.setComplexName(cname);
 		complexConfig.setComplexType(ctype);
 		complexConfig.setComplexVersion(cversion);
 		complexConfig.setSimpleConfiguration(simpleConfig2);
 	}
-	
+
 	@Test
 	public void testGetStringAttribute() {
-		assertTrue(simpleConfig.getAttribute("version").equals(version1));
-		assertTrue(simpleConfig.getAttribute("name").equals(name1));
-		assertTrue(simpleConfig.getAttribute("type").equals(type1));
+		assertTrue(getValue(simpleConfig, "version").equals(version1));
+		assertTrue(getValue(simpleConfig, "name").equals(name1));
+		assertTrue(getValue(simpleConfig, "type").equals(type1));
 	}
-	
+
 	@Test
 	public void testGetObjectAttribute() {
-		SimpleConfiguration config = complexConfig.getAttribute(SimpleConfiguration.class, "simpleConfiguration");
+		SimpleConfiguration config = (SimpleConfiguration) getValue(complexConfig, "simpleConfiguration");
 		assertTrue(config.getName().equals(name2));
 		assertTrue(config.getVersion().equals(version2));
 		assertTrue(config.getType().equals(type2));
 	}
-	
+
 	@Test
 	public void testGetStringObjectAttributeInPlaceOfSimpleAttribute() {
-		simpleConfig.getAttribute(String.class, "name");
+		getValue(simpleConfig, "name");
 	}
-	
-	@Test(expected=RequirementException.class)
+
+	@Test(expected = RequirementException.class)
 	public void testGetAttributeOfComplexConfiguration() {
-		simpleConfig.getAttribute(ComplexConfiguration.class, "name");
+		getValue(complexConfig, "name");
 	}
-	
-	@Test(expected=RequirementException.class)
+
+	@Test(expected = RequirementException.class)
 	public void getNonexistingStringAttribute() {
-		simpleConfig.getAttribute("idontexist");
+		getValue(simpleConfig, "idontexist");
 	}
-	
-	@Test(expected=RequirementException.class)
+
+	@Test(expected = RequirementException.class)
 	public void testGetNonexistingObjectAttribute() {
-		simpleConfig.getAttribute(SimpleConfiguration.class, "simpleConfiguration");
+		getValue(simpleConfig, "simpleConfiguration");
 	}
-	
-	@Test(expected=RequirementException.class)
-	public void testGetAttributeWithWrongAttributeClassAndCorrectAttributeName() {
-		complexConfig.getAttribute(ComplexConfiguration.class, "simpleConfiguration");
-	}
-	
-	@Test(expected=RequirementException.class)
-	public void testGetAttributeWithWrongAttributeClassAndWrongAttributeName() {
-		complexConfig.getAttribute(ComplexConfiguration.class, "idontexist");
-	}
+
 }

--- a/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/util/ReflectionUtilTest.java
+++ b/tests/org.eclipse.reddeer.junit.test/src/org/eclipse/reddeer/junit/test/util/ReflectionUtilTest.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.reddeer.junit.test.util;
+
+import static org.eclipse.reddeer.junit.util.ReflectionUtil.getValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.eclipse.reddeer.junit.requirement.RequirementException;
+import org.junit.Test;
+
+/**
+ * 
+ * @author Andrej Podhradsky (apodhrad@redhat.com)
+ *
+ */
+public class ReflectionUtilTest {
+
+	@Test
+	public void testGettingSimpleValue() {
+		A a = new A();
+		a.setName("aaa");
+
+		assertEquals("aaa", getValue(a, "name"));
+	}
+
+	@Test
+	public void testGettingInheritedValue() {
+		B b = new B();
+		b.setName("bbb");
+
+		assertEquals("bbb", getValue(b, "name"));
+	}
+
+	@Test
+	public void testGettingComplexValue() {
+		A a = new A();
+		a.setName("aaa");
+		B b = new B();
+		b.setName("bbb");
+		b.setA(a);
+
+		assertEquals("aaa", getValue(b, "a.name"));
+	}
+
+	@Test
+	public void testGettingObjectValue() {
+		A a = new A();
+		a.setName("aaa");
+		B b = new B();
+		b.setName("bbb");
+		b.setA(a);
+
+		assertEquals(a, getValue(b, "a"));
+	}
+
+	@Test
+	public void testGettingNonAttributeValue() {
+		A a = new A();
+		a.setName("aaa");
+
+		assertEquals(A.class, getValue(a, "class"));
+	}
+
+	@Test
+	public void testGettingNullAttributeValue() {
+		A a = new A();
+
+		assertNull(getValue(a, "name"));
+	}
+
+	@Test
+	public void testHandlingNonExistingAttributeValue() {
+		A a = new A();
+		a.setName("aaa");
+
+		try {
+			getValue(a, "surname");
+		} catch (RequirementException e) {
+			assertEquals("Cannot access surname in " + A.class.getCanonicalName(), e.getMessage());
+			return;
+		}
+		fail("A requirement exception was expected");
+	}
+
+	@Test
+	public void testHandlingNPE() {
+		B b = new B();
+
+		try {
+			getValue(b, "a.name");
+		} catch (RequirementException e) {
+			assertEquals("Cannot access a.name since a was resolved as null", e.getMessage());
+			return;
+		}
+		fail("A requirement exception was expected");
+	}
+
+	public static class A {
+
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+	}
+
+	public static class B extends A {
+
+		private A a;
+
+		public A getA() {
+			return a;
+		}
+
+		public void setA(A a) {
+			this.a = a;
+		}
+
+	}
+}


### PR DESCRIPTION
Assume we want to use a requirement matcher for "fuseServer.host" in the following configuration
```
FuseConfiguration
- camelVersion
- fuseServer
  - host
  - username
  - password
```
At the moment, RedDeer requires the following definitions
```
FuseConfiguration implements RequirementConfiguration
FuseServer implements RequirementConfiguration
```
Do we really want to implement RequirementConfiguration in all inner classes?