### PR TITLE
Add catch block in cleanup() method in test KeyboardTest (fixes #1863)

### DIFF
--- a/tests/org.eclipse.reddeer.swt.test/src/org/eclipse/reddeer/swt/test/keyboard/KeyboardTest.java
+++ b/tests/org.eclipse.reddeer.swt.test/src/org/eclipse/reddeer/swt/test/keyboard/KeyboardTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.reddeer.common.exception.RedDeerException;
 import org.eclipse.reddeer.common.util.Display;
 import org.eclipse.reddeer.common.util.ResultRunnable;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
@@ -35,13 +36,17 @@ public class KeyboardTest {
 	
 	@After
 	public void cleanup() {
-		Display.syncExec(new Runnable() {
+		try {
+			Display.syncExec(new Runnable() {
 
-			@Override
-			public void run() {
-				ShellTestUtils.closeShell(SHELL_TITLE);
-			}
-		});
+				@Override
+				public void run() {
+					ShellTestUtils.closeShell(SHELL_TITLE);
+				}
+			});
+		} catch (RedDeerException ex) {
+			// keyCombinationTest does not open shell with title SHELL_TITLE
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Josef Kopriva <jkopriva@redhat.com>