### PR TITLE
Improve the message when a specified menu item is not found

### DIFF
--- a/tests/org.eclipse.reddeer.swt.test/src/org/eclipse/reddeer/swt/test/impl/menu/ShellMenuTest.java
+++ b/tests/org.eclipse.reddeer.swt.test/src/org/eclipse/reddeer/swt/test/impl/menu/ShellMenuTest.java
@@ -12,8 +12,10 @@ package org.eclipse.reddeer.swt.test.impl.menu;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.eclipse.reddeer.core.exception.CoreLayerException;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.eclipse.reddeer.swt.api.Menu;
 import org.eclipse.reddeer.swt.api.Shell;
@@ -62,6 +64,40 @@ public class ShellMenuTest extends AbstractMenuTest{
 		Shell shell = new DefaultShell(SHELL_TEXT);
 		Menu menu = new ContextMenu(shell);
 		assertFalse(menu.hasItem("ShellMenuBarItemX"));
+	}
+
+	@Test
+	public void testErrorMessageForNonexistingMenuItem() {
+		Shell shell = new DefaultShell(SHELL_TEXT);
+		Menu menu = new ShellMenu(shell);
+		String msg = null;
+		try {
+			menu.getItem("ShellMenuBarItemX");
+		} catch (CoreLayerException e) {
+			msg = e.getMessage();
+		}
+		assertNotNull(msg);
+		assertEquals(
+				"No menu item matching Matcher matching widgets with text that without mnenomic matches: is \"ShellMenuBarItemX\" was found.\n"
+						+ "The following items were found on path '/':\n" + "	ShellMenuBarItem",
+				msg);
+	}
+
+	@Test
+	public void testErrorMessageForNonexistingComplexMenuItem() {
+		Shell shell = new DefaultShell(SHELL_TEXT);
+		Menu menu = new ShellMenu(shell);
+		String msg = null;
+		try {
+			menu.getItem("ShellMenuBarItem", "ShellMenuBarItem1X");
+		} catch (CoreLayerException e) {
+			msg = e.getMessage();
+		}
+		assertNotNull(msg);
+		assertEquals(
+				"No menu item matching Matcher matching widgets with text that without mnenomic matches: is \"ShellMenuBarItem\", Matcher matching widgets with text that without mnenomic matches: is \"ShellMenuBarItem1X\" was found.\n"
+						+ "The following items were found on path '/ShellMenuBarItem':\n" + "	ShellMenuBarItem1",
+				msg);
 	}
 
 }


### PR DESCRIPTION
Currently, there is the following message
```
"No menu item matching specified path found"
```