### PR TITLE
Reset perspective fails with Eclipse Platform 4.8 I-builds

### DIFF
--- a/plugins/org.eclipse.reddeer.eclipse/src/org/eclipse/reddeer/eclipse/ui/perspectives/AbstractPerspective.java
+++ b/plugins/org.eclipse.reddeer.eclipse/src/org/eclipse/reddeer/eclipse/ui/perspectives/AbstractPerspective.java
@@ -120,7 +120,17 @@ public abstract class AbstractPerspective {
 		
 		menu.select();
 		new DefaultShell("Reset Perspective");
-		new YesButton().click();
+		WidgetIsFound resetButton = new WidgetIsFound(org.eclipse.swt.widgets.Button.class,
+				new WithMnemonicTextMatcher("Reset Perspective"));
+		
+		
+		Button button;
+		if(resetButton.test()){
+			button = new PushButton("Reset Perspective"); //photon changed button text
+		} else {
+			button = new YesButton();	
+		}
+		button.click();
 	}
 
 	/**


### PR DESCRIPTION
Test for Reset Perspective button instead of Yes for Photon changes.


Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>