### PR TITLE
REDDEER-1854 Move getContextMenu implementation to AbstractWorkbenchPart

### DIFF
--- a/plugins/org.eclipse.reddeer.eclipse/src/org/eclipse/reddeer/eclipse/ui/console/ConsoleView.java
+++ b/plugins/org.eclipse.reddeer.eclipse/src/org/eclipse/reddeer/eclipse/ui/console/ConsoleView.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.reddeer.eclipse.ui.console;
 
-import org.hamcrest.Matcher;
-import org.hamcrest.core.IsEqual;
 import org.eclipse.reddeer.common.condition.AbstractWaitCondition;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
@@ -27,6 +25,9 @@ import org.eclipse.reddeer.swt.impl.menu.ToolItemMenuItem;
 import org.eclipse.reddeer.swt.impl.styledtext.DefaultStyledText;
 import org.eclipse.reddeer.swt.impl.toolbar.DefaultToolItem;
 import org.eclipse.reddeer.workbench.impl.view.WorkbenchView;
+import org.eclipse.swt.widgets.Control;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsEqual;
 
 /**
  * Represents Console view in Eclipse
@@ -244,4 +245,23 @@ public class ConsoleView extends WorkbenchView {
 		org.eclipse.swt.widgets.Widget swtWidget = widgetIsFound.getResult();
 		return (swtWidget == null) ? null : LabelHandler.getInstance().getText((org.eclipse.swt.widgets.Label)swtWidget);
 	}
+
+	/**
+	 * Returns a control registered via adapters. This is usually StyledText or
+	 * Canvas.
+	 * 
+	 * @return registered control
+	 */
+	protected Control getRegisteredControl() {
+		activate();
+		WidgetIsFound widgetIsFound = new WidgetIsFound(org.eclipse.swt.custom.StyledText.class, cTabItem.getControl());
+		new WaitUntil(widgetIsFound, TimePeriod.SHORT, false);
+		// Check whether there is a console to display or not
+		if (widgetIsFound.getResult() == null) {
+			log.debug("There is no console in console view.");
+			return null;
+		}
+		return (org.eclipse.swt.custom.StyledText) widgetIsFound.getResult();
+	}
+
 }

--- a/plugins/org.eclipse.reddeer.workbench/src/org/eclipse/reddeer/workbench/api/Editor.java
+++ b/plugins/org.eclipse.reddeer.workbench/src/org/eclipse/reddeer/workbench/api/Editor.java
@@ -121,11 +121,4 @@ public interface Editor extends WorkbenchPart {
 	 * @return Editor file associated to the editor
 	 */
 	EditorFile getAssociatedFile();
-
-	/**
-	 * Returns a context menu associated to the editor.
-	 * 
-	 * @return Context menu associated to the editor
-	 */
-	Menu getContextMenu();
 }

--- a/plugins/org.eclipse.reddeer.workbench/src/org/eclipse/reddeer/workbench/api/WorkbenchPart.java
+++ b/plugins/org.eclipse.reddeer.workbench/src/org/eclipse/reddeer/workbench/api/WorkbenchPart.java
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package org.eclipse.reddeer.workbench.api;
 
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.reddeer.core.reference.ReferencedComposite;
+import org.eclipse.reddeer.swt.api.Menu;
+import org.eclipse.swt.graphics.Image;
 
 /**
  * Interface with base operations which can be performed with workbench part.
@@ -70,4 +71,10 @@ public interface WorkbenchPart extends ReferencedComposite {
 	 */
 	void restore();
 
+	/**
+	 * Returns a context menu associated to the WorkbenchPart.
+	 * 
+	 * @return Context menu associated to the WorkbenchPart
+	 */
+	Menu getContextMenu();
 }

--- a/plugins/org.eclipse.reddeer.workbench/src/org/eclipse/reddeer/workbench/impl/editor/AbstractEditor.java
+++ b/plugins/org.eclipse.reddeer.workbench/src/org/eclipse/reddeer/workbench/impl/editor/AbstractEditor.java
@@ -26,16 +26,13 @@ import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.core.handler.MenuItemHandler;
-import org.eclipse.reddeer.core.lookup.MenuLookup;
 import org.eclipse.reddeer.core.lookup.ShellLookup;
 import org.eclipse.reddeer.core.matcher.WithTextMatcher;
 import org.eclipse.reddeer.core.reference.ReferencedComposite;
 import org.eclipse.reddeer.core.util.InstanceValidator;
 import org.eclipse.reddeer.jface.text.contentassist.ContentAssistant;
-import org.eclipse.reddeer.swt.api.Menu;
 import org.eclipse.reddeer.swt.api.MenuItem;
 import org.eclipse.reddeer.swt.impl.ctab.DefaultCTabItem;
-import org.eclipse.reddeer.swt.impl.menu.DefaultMenu;
 import org.eclipse.reddeer.swt.impl.menu.ShellMenuItem;
 import org.eclipse.reddeer.swt.keyboard.KeyboardFactory;
 import org.eclipse.reddeer.workbench.api.Editor;
@@ -325,21 +322,6 @@ public abstract class AbstractEditor extends AbstractWorkbenchPart implements Ed
 			throw new WorkbenchLayerException("No file is associated to the editor");
 		}
 		return new DefaultEditorFile(iFile);
-	}
-
-	/**
-	 * Returns a context menu associated to the editor. The context menu is obtained from a registered control. If this
-	 * control doesn't meet your requirements you can change it by overriding {{@link #getRegisteredControl()}}.
-	 * 
-	 * @return Context menu associated to the editor
-	 */
-	@Override
-	public Menu getContextMenu() {
-		Control registeredControl = getRegisteredControl();
-		if (registeredControl == null) {
-			throw new WorkbenchLayerException("No control is registered with the editor");
-		}
-		return new DefaultMenu(MenuLookup.getInstance().getControlMenu(registeredControl));
 	}
 
 	/**

--- a/plugins/org.eclipse.reddeer.workbench/src/org/eclipse/reddeer/workbench/part/AbstractWorkbenchPart.java
+++ b/plugins/org.eclipse.reddeer.workbench/src/org/eclipse/reddeer/workbench/part/AbstractWorkbenchPart.java
@@ -10,13 +10,17 @@
  *******************************************************************************/
 package org.eclipse.reddeer.workbench.part;
 
+import org.eclipse.reddeer.common.logging.Logger;
+import org.eclipse.reddeer.core.lookup.MenuLookup;
+import org.eclipse.reddeer.swt.api.CTabItem;
+import org.eclipse.reddeer.swt.api.Menu;
+import org.eclipse.reddeer.swt.impl.menu.DefaultMenu;
+import org.eclipse.reddeer.workbench.api.WorkbenchPart;
+import org.eclipse.reddeer.workbench.exception.WorkbenchLayerException;
+import org.eclipse.reddeer.workbench.handler.WorkbenchPartHandler;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.actions.ActionFactory;
-import org.eclipse.reddeer.common.logging.Logger;
-import org.eclipse.reddeer.swt.api.CTabItem;
-import org.eclipse.reddeer.workbench.api.WorkbenchPart;
-import org.eclipse.reddeer.workbench.handler.WorkbenchPartHandler;
 
 /**
  * Abstract class for all WorkbenchPart implementations
@@ -80,5 +84,36 @@ public abstract class AbstractWorkbenchPart implements WorkbenchPart {
 		// in order to restore maximized window maximized action has to be called
 		WorkbenchPartHandler.getInstance().performAction(ActionFactory.MAXIMIZE);
 	}
+	
+	/**
+	 * Returns a context menu associated to the workbench. The context menu is
+	 * obtained from a registered control. If this control doesn't meet your
+	 * requirements you can change it by overriding
+	 * {{@link #getRegisteredControl()}}.
+	 * 
+	 * @return Context menu associated to the editor
+	 */
+	@Override
+	public Menu getContextMenu() {
+		Control registeredControl = getRegisteredControl();
+		if (registeredControl == null) {
+			throw new WorkbenchLayerException("No control is registered with the workbench");
+		}
+		return new DefaultMenu(MenuLookup.getInstance().getControlMenu(registeredControl));
+	}
 
+	/**
+	 * Returns a control registered via adapters. This is usually StyledText or
+	 * Canvas.
+	 * 
+	 * @return registered control
+	 */
+	protected Control getRegisteredControl() {
+		CTabItem cTabItem = getCTabItem();
+		return cTabItem.getControl();
+	}
+	
+	public CTabItem getCTabItem() {
+		return cTabItem;
+	}
 }

--- a/tests/org.eclipse.reddeer.eclipse.test/src/org/eclipse/reddeer/eclipse/test/ui/console/ConsoleViewTest.java
+++ b/tests/org.eclipse.reddeer.eclipse.test/src/org/eclipse/reddeer/eclipse/test/ui/console/ConsoleViewTest.java
@@ -14,6 +14,7 @@ import static org.eclipse.reddeer.common.wait.WaitProvider.waitUntil;
 import static org.eclipse.reddeer.common.wait.WaitProvider.waitWhile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import org.eclipse.reddeer.common.matcher.RegexMatcher;
@@ -38,6 +39,8 @@ import org.eclipse.reddeer.eclipse.ui.perspectives.JavaPerspective;
 import org.eclipse.reddeer.eclipse.utils.DeleteUtils;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.swt.api.Menu;
+import org.eclipse.reddeer.swt.api.MenuItem;
 import org.eclipse.reddeer.swt.api.StyledText;
 import org.eclipse.reddeer.swt.impl.menu.ShellMenuItem;
 import org.eclipse.reddeer.swt.impl.styledtext.DefaultStyledText;
@@ -179,6 +182,19 @@ public class ConsoleViewTest {
 		consoleView.open();
 		consoleView.toggleShowConsoleOnStandardOutChange(true);
 		consoleView.toggleShowConsoleOnStandardOutChange(false);
+	}
+	
+	@Test
+	public void getContextMenuTest() {
+		ConsoleView consoleView = new ConsoleView();
+		consoleView.open();
+		
+		runTestClass(TEST_CLASS_NAME);
+		AbstractWait.sleep(TimePeriod.SHORT);
+		
+		Menu contextMenu = consoleView.getContextMenu();
+		MenuItem clear = contextMenu.getItem("Clear");
+		assertNotNull(clear);
 	}
 
 	@After


### PR DESCRIPTION
REDDEER-1854 Move getContextMenu implementation to AbstractWorkbenchPart so it may be used in all Views. Some views may need to override getRegisteredControl method, as I already did in ConsoleView.

Signed-off-by: Lukáš Valach <lvalach@redhat.com>