### PR TITLE
OpenPerspective Req. fails on Photon

### DIFF
--- a/plugins/org.eclipse.reddeer.eclipse/src/org/eclipse/reddeer/eclipse/ui/perspectives/AbstractPerspective.java
+++ b/plugins/org.eclipse.reddeer.eclipse/src/org/eclipse/reddeer/eclipse/ui/perspectives/AbstractPerspective.java
@@ -102,6 +102,30 @@ public abstract class AbstractPerspective {
 		if (!isOpened()) {
 			throw new EclipseLayerException("Trying to reset perspective that is not open");
 		}
+		MenuItem menu = getResetMenuItem();
+		menu.select();
+		new DefaultShell("Reset Perspective");
+		WidgetIsFound resetButton = new WidgetIsFound(org.eclipse.swt.widgets.Button.class,
+				new WithMnemonicTextMatcher("Reset Perspective"));
+
+		Button button;
+		if (resetButton.test()) {
+			button = new PushButton("Reset Perspective"); // photon changed button text
+		} else {
+			button = new YesButton();
+		}
+		button.click();
+	}
+
+	/**
+	 * Returns true if reset perspective menu item is enabled, false otherwise
+	 * @return true if reset perspective menu item is enabled, false otherwise
+	 */
+	public boolean isResetEnabled() {
+		return getResetMenuItem().isEnabled();
+	}
+
+	private MenuItem getResetMenuItem() {
 		// Prior to Eclipse Mars path to Reset Perspective menu
 		WithTextMatchers m = new WithTextMatchers(
 				new RegexMatcher[] { new RegexMatcher("Window.*"), new RegexMatcher("Reset Perspective...") });
@@ -114,20 +138,7 @@ public abstract class AbstractPerspective {
 					new RegexMatcher("Perspective.*"), new RegexMatcher("Reset Perspective...") });
 			menu = new ShellMenuItem(m.getMatchers());
 		}
-
-		menu.select();
-		new DefaultShell("Reset Perspective");
-		WidgetIsFound resetButton = new WidgetIsFound(org.eclipse.swt.widgets.Button.class,
-				new WithMnemonicTextMatcher("Reset Perspective"));
-		
-		
-		Button button;
-		if(resetButton.test()){
-			button = new PushButton("Reset Perspective"); //photon changed button text
-		} else {
-			button = new YesButton();	
-		}
-		button.click();
+		return menu;
 	}
 
 	/**

--- a/plugins/org.eclipse.reddeer.requirements/src/org/eclipse/reddeer/requirements/openperspective/OpenPerspectiveRequirement.java
+++ b/plugins/org.eclipse.reddeer.requirements/src/org/eclipse/reddeer/requirements/openperspective/OpenPerspectiveRequirement.java
@@ -16,10 +16,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.eclipse.reddeer.common.condition.AbstractWaitCondition;
+import org.eclipse.reddeer.common.logging.Logger;
+import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.eclipse.ui.perspectives.AbstractPerspective;
 import org.eclipse.reddeer.junit.requirement.Requirement;
 import org.eclipse.reddeer.requirements.exception.RequirementsLayerException;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.swt.condition.MenuItemIsEnabled;
 
 /**
  * Open perspective requirement<br><br>
@@ -42,6 +47,8 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
  * 
  */
 public class OpenPerspectiveRequirement implements Requirement<OpenPerspective> {
+	
+	protected final Logger log = Logger.getLogger(this.getClass());
 
 	/**
 	 * Marks test class, which requires opening of the specified perspective.
@@ -80,6 +87,18 @@ public class OpenPerspectiveRequirement implements Requirement<OpenPerspective> 
 			perspective.open();
 			
 			if (openPerspective.reset()){
+				new WaitUntil(new AbstractWaitCondition() {
+					
+					@Override
+					public boolean test() {
+						return perspective.isResetEnabled();
+					}
+					
+				}, TimePeriod.SHORT, false);
+				if(!perspective.isResetEnabled()) {
+					log.info("Reset Perspective menu is not enabled, skipping");
+					return;
+				}
 				perspective.reset();				
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
Reset Perspective menu item is disabled for a very short time and the default behavior of the requirement is to reset the perspective which fails.