### PR TITLE
Removing org.apache.lucene imports due to #2064

### DIFF
--- a/tests/org.eclipse.reddeer.eclipse.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.reddeer.eclipse.test/META-INF/MANIFEST.MF
@@ -18,8 +18,6 @@ Require-Bundle: org.eclipse.reddeer.go;bundle-version="[2.2.0,2.9.1)",
  org.eclipse.datatools.connectivity.dbdefinition.genericJDBC,
  org.eclipse.datatools.sqltools.sqlscrapbook;bundle-version="1.0.2",
  org.eclipse.datatools.sqltools.result.ui;bundle-version="1.1.3",
- org.apache.lucene.core;bundle-version="8.0.0",
- org.apache.lucene.misc;bundle-version="8.0.0",
  org.eclipse.epp.logging.aeri.core;bundle-version="[2.0.0,3.0.0)";resolution:=optional,
  org.eclipse.epp.logging.aeri.ide;bundle-version="[2.0.0,3.0.0)";resolution:=optional,
  org.eclipse.jdt.ui


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?
* Is copyright with correct year in new files?
* Is there a JavaDoc in every class with description of a class and an author(and issue if suitable)?
* Is there a link to github project issue? (if needed)

## Testing
* Does it work?
* Are the tests green on Jenkins? Is there a link to Jenkins build?
